### PR TITLE
feat(firmware): implement MAVLink serial bridge component

### DIFF
--- a/firmware/.gitignore
+++ b/firmware/.gitignore
@@ -3,3 +3,4 @@ sdkconfig
 sdkconfig.old
 managed_components/
 dependencies.lock
+test/test_mavlink_parser

--- a/firmware/components/mavlink_bridge/CMakeLists.txt
+++ b/firmware/components/mavlink_bridge/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "mavlink_bridge.c" "mavlink_parser.c"
+    INCLUDE_DIRS "include"
+    PRIV_REQUIRES driver micro_ros_espidf_component
+)

--- a/firmware/components/mavlink_bridge/Kconfig
+++ b/firmware/components/mavlink_bridge/Kconfig
@@ -1,0 +1,30 @@
+menu "MAVLink Bridge"
+
+    config MAVLINK_UART_NUM
+        int "UART peripheral number"
+        default 1
+        range 0 2
+        help
+            UART peripheral used for the MAVLink connection to the flight
+            controller.  UART0 is usually reserved for the console log.
+
+    config MAVLINK_UART_TX_PIN
+        int "TX GPIO pin"
+        default 21
+        help
+            GPIO pin for UART TX to the flight controller (→ H743 RX4).
+
+    config MAVLINK_UART_RX_PIN
+        int "RX GPIO pin"
+        default 20
+        help
+            GPIO pin for UART RX from the flight controller (← H743 TX4).
+
+    config MAVLINK_UART_BAUD
+        int "Baud rate"
+        default 921600
+        help
+            Baud rate for the MAVLink UART link.  Must match ArduCopter
+            SERIAL6_BAUD (921 = 921600).
+
+endmenu

--- a/firmware/components/mavlink_bridge/include/mavlink_bridge.h
+++ b/firmware/components/mavlink_bridge/include/mavlink_bridge.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <esp_err.h>
+#include <rcl/rcl.h>
+#include <rclc/executor.h>
+
+/* Number of executor handles this component adds (1 subscription). */
+#define MAVLINK_BRIDGE_NUM_HANDLES 1
+
+/* Initialise UART for MAVLink communication with the flight controller.
+   Uses CONFIG_MAVLINK_UART_* Kconfig values for pin/baud configuration. */
+esp_err_t mavlink_bridge_init(void);
+
+/* Create the micro-ROS publisher (mavlink/from_fc) and subscriber
+   (mavlink/to_fc) on the given node, and register the subscriber with
+   the executor.  Call after mavlink_bridge_init(). */
+esp_err_t mavlink_bridge_create(rcl_node_t *node, rclc_executor_t *executor);
+
+/* Start the UART reader FreeRTOS task.  Incoming MAVLink frames are
+   published to the from_fc topic.  Call after mavlink_bridge_create(). */
+esp_err_t mavlink_bridge_start(void);

--- a/firmware/components/mavlink_bridge/include/mavlink_parser.h
+++ b/firmware/components/mavlink_bridge/include/mavlink_parser.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define MAVLINK_V1_STX 0xFE
+#define MAVLINK_V2_STX 0xFD
+
+#define MAVLINK_V1_HEADER_LEN  6  /* STX + LEN + SEQ + SYSID + COMPID + MSGID */
+#define MAVLINK_V2_HEADER_LEN 10  /* STX + LEN + 2×FLAGS + SEQ + SYSID + COMPID + 3×MSGID */
+#define MAVLINK_CHECKSUM_LEN   2
+#define MAVLINK_SIGNATURE_LEN 13
+#define MAVLINK_MAX_PAYLOAD_LEN 255
+#define MAVLINK_MAX_FRAME_LEN \
+    (MAVLINK_V2_HEADER_LEN + MAVLINK_MAX_PAYLOAD_LEN + \
+     MAVLINK_CHECKSUM_LEN + MAVLINK_SIGNATURE_LEN) /* 280 */
+
+typedef enum {
+    MAVLINK_PARSE_IDLE,
+    MAVLINK_PARSE_GOT_STX,
+    MAVLINK_PARSE_ACCUMULATING,
+} mavlink_parse_state_t;
+
+typedef enum {
+    MAVLINK_PARSER_INCOMPLETE,
+    MAVLINK_PARSER_COMPLETE,
+} mavlink_parser_result_t;
+
+typedef struct {
+    mavlink_parse_state_t state;
+    uint8_t buf[MAVLINK_MAX_FRAME_LEN];
+    size_t idx;
+    size_t expected_len;
+} mavlink_parser_t;
+
+/* Reset the parser to its initial state. */
+void mavlink_parser_init(mavlink_parser_t *parser);
+
+/* Feed one byte to the parser.
+   Returns MAVLINK_PARSER_COMPLETE when a full frame has been accumulated.
+   After getting COMPLETE, call mavlink_parser_get_frame() then
+   mavlink_parser_init() before parsing more bytes. */
+mavlink_parser_result_t mavlink_parser_parse_byte(mavlink_parser_t *parser,
+                                                  uint8_t byte);
+
+/* Get the accumulated frame buffer and its length.
+   Only valid after mavlink_parser_parse_byte() returns COMPLETE. */
+void mavlink_parser_get_frame(const mavlink_parser_t *parser,
+                              const uint8_t **buf, size_t *len);

--- a/firmware/components/mavlink_bridge/mavlink_bridge.c
+++ b/firmware/components/mavlink_bridge/mavlink_bridge.c
@@ -1,0 +1,209 @@
+#include "mavlink_bridge.h"
+#include "mavlink_parser.h"
+
+#include <string.h>
+
+#include "driver/uart.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include <rcl/rcl.h>
+#include <rclc/rclc.h>
+#include <std_msgs/msg/u_int8_multi_array.h>
+
+static const char *TAG = "mavlink_bridge";
+
+/* UART buffer sizes. RX needs headroom for bursts; TX can be smaller
+   since we write complete frames at once. */
+#define UART_RX_BUF_SIZE 1024
+#define UART_TX_BUF_SIZE 512
+
+/* Stack for the UART reader task. 4 KB is sufficient for UART reads,
+   parser state, and a single rcl_publish call. */
+#define UART_TASK_STACK_SIZE 4096
+#define UART_TASK_PRIORITY   4
+
+/* Chunk size for uart_read_bytes per iteration. */
+#define UART_READ_CHUNK 128
+
+/* ── static state ─────────────────────────────────────────────── */
+
+static rcl_publisher_t  pub_from_fc;
+static rcl_subscription_t sub_to_fc;
+
+/* Publisher message — statically allocated. */
+static std_msgs__msg__UInt8MultiArray pub_msg;
+static uint8_t pub_msg_buf[MAVLINK_MAX_FRAME_LEN];
+
+/* Subscriber message — statically allocated. */
+static std_msgs__msg__UInt8MultiArray sub_msg;
+static uint8_t sub_msg_buf[MAVLINK_MAX_FRAME_LEN];
+
+static mavlink_parser_t parser;
+
+/* ── subscriber callback ─────────────────────────────────────── */
+
+static void mavlink_to_fc_cb(const void *msg_in)
+{
+    const std_msgs__msg__UInt8MultiArray *msg =
+        (const std_msgs__msg__UInt8MultiArray *)msg_in;
+
+    if (msg->data.size == 0 || msg->data.size > MAVLINK_MAX_FRAME_LEN) {
+        ESP_LOGW(TAG, "to_fc: invalid frame size %zu", msg->data.size);
+        return;
+    }
+
+    int written = uart_write_bytes(CONFIG_MAVLINK_UART_NUM,
+                                   msg->data.data, msg->data.size);
+    if (written < 0) {
+        ESP_LOGE(TAG, "uart_write_bytes failed");
+    }
+}
+
+/* ── UART reader task ────────────────────────────────────────── */
+
+static void mavlink_uart_task(void *arg)
+{
+    uint8_t rx_buf[UART_READ_CHUNK];
+
+    ESP_LOGI(TAG, "UART reader task started (UART%d, %d baud)",
+             CONFIG_MAVLINK_UART_NUM, CONFIG_MAVLINK_UART_BAUD);
+
+    while (true) {
+        int len = uart_read_bytes(CONFIG_MAVLINK_UART_NUM, rx_buf,
+                                  sizeof(rx_buf), pdMS_TO_TICKS(20));
+        if (len <= 0) {
+            continue;
+        }
+
+        for (int i = 0; i < len; i++) {
+            mavlink_parser_result_t res =
+                mavlink_parser_parse_byte(&parser, rx_buf[i]);
+
+            if (res == MAVLINK_PARSER_COMPLETE) {
+                const uint8_t *frame;
+                size_t frame_len;
+                mavlink_parser_get_frame(&parser, &frame, &frame_len);
+
+                memcpy(pub_msg.data.data, frame, frame_len);
+                pub_msg.data.size = frame_len;
+
+                rcl_ret_t rc = rcl_publish(&pub_from_fc, &pub_msg, NULL);
+                if (rc != RCL_RET_OK) {
+                    ESP_LOGW(TAG, "publish from_fc failed: %d", (int)rc);
+                }
+
+                mavlink_parser_init(&parser);
+            }
+        }
+    }
+
+    vTaskDelete(NULL);
+}
+
+/* ── message initialisation ──────────────────────────────────── */
+
+static void init_messages(void)
+{
+    /* DESIGN: static allocation avoids heap fragmentation on the ESP32.
+       Layout fields are unused — we transport raw byte sequences only. */
+    pub_msg.data.data     = pub_msg_buf;
+    pub_msg.data.size     = 0;
+    pub_msg.data.capacity = sizeof(pub_msg_buf);
+    pub_msg.layout.dim.data     = NULL;
+    pub_msg.layout.dim.size     = 0;
+    pub_msg.layout.dim.capacity = 0;
+    pub_msg.layout.data_offset  = 0;
+
+    sub_msg.data.data     = sub_msg_buf;
+    sub_msg.data.size     = 0;
+    sub_msg.data.capacity = sizeof(sub_msg_buf);
+    sub_msg.layout.dim.data     = NULL;
+    sub_msg.layout.dim.size     = 0;
+    sub_msg.layout.dim.capacity = 0;
+    sub_msg.layout.data_offset  = 0;
+}
+
+/* ── public API ──────────────────────────────────────────────── */
+
+esp_err_t mavlink_bridge_init(void)
+{
+    const uart_config_t uart_cfg = {
+        .baud_rate  = CONFIG_MAVLINK_UART_BAUD,
+        .data_bits  = UART_DATA_8_BITS,
+        .parity     = UART_PARITY_DISABLE,
+        .stop_bits  = UART_STOP_BITS_1,
+        .flow_ctrl  = UART_HW_FLOWCTRL_DISABLE,
+        .source_clk = UART_SCLK_DEFAULT,
+    };
+
+    ESP_ERROR_CHECK(uart_driver_install(CONFIG_MAVLINK_UART_NUM,
+                                        UART_RX_BUF_SIZE, UART_TX_BUF_SIZE,
+                                        0, NULL, 0));
+    ESP_ERROR_CHECK(uart_param_config(CONFIG_MAVLINK_UART_NUM, &uart_cfg));
+    ESP_ERROR_CHECK(uart_set_pin(CONFIG_MAVLINK_UART_NUM,
+                                 CONFIG_MAVLINK_UART_TX_PIN,
+                                 CONFIG_MAVLINK_UART_RX_PIN,
+                                 UART_PIN_NO_CHANGE,
+                                 UART_PIN_NO_CHANGE));
+
+    mavlink_parser_init(&parser);
+    init_messages();
+
+    ESP_LOGI(TAG, "UART%d initialised (TX=%d, RX=%d, baud=%d)",
+             CONFIG_MAVLINK_UART_NUM, CONFIG_MAVLINK_UART_TX_PIN,
+             CONFIG_MAVLINK_UART_RX_PIN, CONFIG_MAVLINK_UART_BAUD);
+
+    return ESP_OK;
+}
+
+esp_err_t mavlink_bridge_create(rcl_node_t *node, rclc_executor_t *executor)
+{
+    rcl_allocator_t alloc = rcl_get_default_allocator();
+    const rosidl_message_type_support_t *type =
+        ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, UInt8MultiArray);
+
+    /* DESIGN: reliable QoS for MAVLink topics — frames must not be dropped
+       between the ground station and the flight controller. */
+    const rmw_qos_profile_t qos = rmw_qos_profile_default;
+
+    /* Publisher: mavlink/from_fc (FC → ground) */
+    rcl_ret_t rc = rclc_publisher_init(
+        &pub_from_fc, node, type, "mavlink/from_fc", &qos);
+    if (rc != RCL_RET_OK) {
+        ESP_LOGE(TAG, "failed to create from_fc publisher: %d", (int)rc);
+        return ESP_FAIL;
+    }
+
+    /* Subscriber: mavlink/to_fc (ground → FC) */
+    rc = rclc_subscription_init(
+        &sub_to_fc, node, type, "mavlink/to_fc", &qos);
+    if (rc != RCL_RET_OK) {
+        ESP_LOGE(TAG, "failed to create to_fc subscriber: %d", (int)rc);
+        return ESP_FAIL;
+    }
+
+    rc = rclc_executor_add_subscription(
+        executor, &sub_to_fc, &sub_msg, &mavlink_to_fc_cb, ON_NEW_DATA);
+    if (rc != RCL_RET_OK) {
+        ESP_LOGE(TAG, "failed to add to_fc subscription to executor: %d",
+                 (int)rc);
+        return ESP_FAIL;
+    }
+
+    ESP_LOGI(TAG, "publisher/subscriber created");
+    return ESP_OK;
+}
+
+esp_err_t mavlink_bridge_start(void)
+{
+    BaseType_t ret = xTaskCreate(mavlink_uart_task, "mavlink",
+                                 UART_TASK_STACK_SIZE, NULL,
+                                 UART_TASK_PRIORITY, NULL);
+    if (ret != pdPASS) {
+        ESP_LOGE(TAG, "failed to create UART reader task");
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}

--- a/firmware/components/mavlink_bridge/mavlink_parser.c
+++ b/firmware/components/mavlink_bridge/mavlink_parser.c
@@ -1,0 +1,69 @@
+#include "mavlink_parser.h"
+
+void mavlink_parser_init(mavlink_parser_t *parser)
+{
+    parser->state = MAVLINK_PARSE_IDLE;
+    parser->idx = 0;
+    parser->expected_len = 0;
+}
+
+mavlink_parser_result_t mavlink_parser_parse_byte(mavlink_parser_t *parser,
+                                                  uint8_t byte)
+{
+    switch (parser->state) {
+    case MAVLINK_PARSE_IDLE:
+        if (byte == MAVLINK_V1_STX || byte == MAVLINK_V2_STX) {
+            parser->buf[0] = byte;
+            parser->idx = 1;
+            parser->state = MAVLINK_PARSE_GOT_STX;
+        }
+        return MAVLINK_PARSER_INCOMPLETE;
+
+    case MAVLINK_PARSE_GOT_STX:
+        /* Second byte is always payload length. */
+        parser->buf[parser->idx++] = byte;
+        if (parser->buf[0] == MAVLINK_V1_STX) {
+            parser->expected_len =
+                MAVLINK_V1_HEADER_LEN + byte + MAVLINK_CHECKSUM_LEN;
+        } else {
+            /* v2: signature presence depends on incompat_flags (byte 2),
+               which we haven't received yet. Start without signature. */
+            parser->expected_len =
+                MAVLINK_V2_HEADER_LEN + byte + MAVLINK_CHECKSUM_LEN;
+        }
+        parser->state = MAVLINK_PARSE_ACCUMULATING;
+        return MAVLINK_PARSER_INCOMPLETE;
+
+    case MAVLINK_PARSE_ACCUMULATING:
+        if (parser->idx >= MAVLINK_MAX_FRAME_LEN) {
+            /* Frame overflow — discard and resync. */
+            mavlink_parser_init(parser);
+            return MAVLINK_PARSER_INCOMPLETE;
+        }
+
+        parser->buf[parser->idx++] = byte;
+
+        /* DESIGN: for v2 frames, check incompat_flags (byte index 2) once
+           available to detect whether a 13-byte signature is appended. */
+        if (parser->buf[0] == MAVLINK_V2_STX && parser->idx == 3) {
+            if (parser->buf[2] & 0x01) {
+                parser->expected_len += MAVLINK_SIGNATURE_LEN;
+            }
+        }
+
+        if (parser->idx >= parser->expected_len) {
+            return MAVLINK_PARSER_COMPLETE;
+        }
+        return MAVLINK_PARSER_INCOMPLETE;
+    }
+
+    /* Unreachable, but satisfy compilers. */
+    return MAVLINK_PARSER_INCOMPLETE;
+}
+
+void mavlink_parser_get_frame(const mavlink_parser_t *parser,
+                              const uint8_t **buf, size_t *len)
+{
+    *buf = parser->buf;
+    *len = parser->idx;
+}

--- a/firmware/components/mavlink_bridge/test/CMakeLists.txt
+++ b/firmware/components/mavlink_bridge/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRC_DIRS "."
+    INCLUDE_DIRS "."
+    REQUIRES unity mavlink_bridge
+)

--- a/firmware/components/mavlink_bridge/test/test_mavlink_parser.c
+++ b/firmware/components/mavlink_bridge/test/test_mavlink_parser.c
@@ -1,0 +1,395 @@
+#include "unity.h"
+#include "mavlink_parser.h"
+
+#include <string.h>
+
+/* ── helpers ─────────────────────────────────────────────────── */
+
+/* Feed an array of bytes to the parser and return the result of the
+   last byte.  Asserts INCOMPLETE for all bytes except the last. */
+static mavlink_parser_result_t feed_bytes(mavlink_parser_t *p,
+                                          const uint8_t *data, size_t len)
+{
+    mavlink_parser_result_t res = MAVLINK_PARSER_INCOMPLETE;
+    for (size_t i = 0; i < len; i++) {
+        res = mavlink_parser_parse_byte(p, data[i]);
+        if (i < len - 1) {
+            TEST_ASSERT_EQUAL(MAVLINK_PARSER_INCOMPLETE, res);
+        }
+    }
+    return res;
+}
+
+/* Build a minimal MAVLink v1 frame (no real CRC — just structure). */
+static size_t build_v1_frame(uint8_t *buf, uint8_t payload_len)
+{
+    size_t idx = 0;
+    buf[idx++] = MAVLINK_V1_STX;          /* STX   */
+    buf[idx++] = payload_len;              /* LEN   */
+    buf[idx++] = 0x00;                     /* SEQ   */
+    buf[idx++] = 0x01;                     /* SYSID */
+    buf[idx++] = 0x01;                     /* COMPID*/
+    buf[idx++] = 0x00;                     /* MSGID */
+    for (uint8_t i = 0; i < payload_len; i++) {
+        buf[idx++] = i;                    /* payload */
+    }
+    buf[idx++] = 0xAA;                     /* CKL   */
+    buf[idx++] = 0xBB;                     /* CKH   */
+    return idx;
+}
+
+/* Build a minimal MAVLink v2 frame (no signature). */
+static size_t build_v2_frame(uint8_t *buf, uint8_t payload_len)
+{
+    size_t idx = 0;
+    buf[idx++] = MAVLINK_V2_STX;          /* STX            */
+    buf[idx++] = payload_len;              /* LEN            */
+    buf[idx++] = 0x00;                     /* INCOMPAT_FLAGS */
+    buf[idx++] = 0x00;                     /* COMPAT_FLAGS   */
+    buf[idx++] = 0x00;                     /* SEQ            */
+    buf[idx++] = 0x01;                     /* SYSID          */
+    buf[idx++] = 0x01;                     /* COMPID         */
+    buf[idx++] = 0x00;                     /* MSGID low      */
+    buf[idx++] = 0x00;                     /* MSGID mid      */
+    buf[idx++] = 0x00;                     /* MSGID high     */
+    for (uint8_t i = 0; i < payload_len; i++) {
+        buf[idx++] = i;
+    }
+    buf[idx++] = 0xCC;                     /* CKL            */
+    buf[idx++] = 0xDD;                     /* CKH            */
+    return idx;
+}
+
+/* Build a MAVLink v2 frame WITH signature (incompat_flags bit 0 set). */
+static size_t build_v2_signed_frame(uint8_t *buf, uint8_t payload_len)
+{
+    size_t idx = 0;
+    buf[idx++] = MAVLINK_V2_STX;
+    buf[idx++] = payload_len;
+    buf[idx++] = 0x01;                     /* INCOMPAT_FLAGS: signing */
+    buf[idx++] = 0x00;
+    buf[idx++] = 0x00;
+    buf[idx++] = 0x01;
+    buf[idx++] = 0x01;
+    buf[idx++] = 0x00;
+    buf[idx++] = 0x00;
+    buf[idx++] = 0x00;
+    for (uint8_t i = 0; i < payload_len; i++) {
+        buf[idx++] = i;
+    }
+    buf[idx++] = 0xEE;                     /* CKL            */
+    buf[idx++] = 0xFF;                     /* CKH            */
+    for (int i = 0; i < MAVLINK_SIGNATURE_LEN; i++) {
+        buf[idx++] = (uint8_t)(0x50 + i);  /* signature      */
+    }
+    return idx;
+}
+
+/* ── init tests ──────────────────────────────────────────────── */
+
+TEST_CASE("parser_init sets idle state", "[mavlink_parser]")
+{
+    mavlink_parser_t p;
+    mavlink_parser_init(&p);
+    TEST_ASSERT_EQUAL(MAVLINK_PARSE_IDLE, p.state);
+    TEST_ASSERT_EQUAL(0, p.idx);
+}
+
+/* ── v1 frame tests ──────────────────────────────────────────── */
+
+TEST_CASE("parse v1 frame with zero-length payload", "[mavlink_parser]")
+{
+    uint8_t frame[16];
+    size_t frame_len = build_v1_frame(frame, 0);
+    TEST_ASSERT_EQUAL(8, frame_len);  /* header(6) + ck(2) */
+
+    mavlink_parser_t p;
+    mavlink_parser_init(&p);
+
+    mavlink_parser_result_t res = feed_bytes(&p, frame, frame_len);
+    TEST_ASSERT_EQUAL(MAVLINK_PARSER_COMPLETE, res);
+
+    const uint8_t *out;
+    size_t out_len;
+    mavlink_parser_get_frame(&p, &out, &out_len);
+    TEST_ASSERT_EQUAL(frame_len, out_len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(frame, out, frame_len);
+}
+
+TEST_CASE("parse v1 frame with 4-byte payload", "[mavlink_parser]")
+{
+    uint8_t frame[16];
+    size_t frame_len = build_v1_frame(frame, 4);
+    TEST_ASSERT_EQUAL(12, frame_len);
+
+    mavlink_parser_t p;
+    mavlink_parser_init(&p);
+
+    mavlink_parser_result_t res = feed_bytes(&p, frame, frame_len);
+    TEST_ASSERT_EQUAL(MAVLINK_PARSER_COMPLETE, res);
+
+    const uint8_t *out;
+    size_t out_len;
+    mavlink_parser_get_frame(&p, &out, &out_len);
+    TEST_ASSERT_EQUAL(frame_len, out_len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(frame, out, frame_len);
+}
+
+TEST_CASE("parse v1 frame with max payload", "[mavlink_parser]")
+{
+    uint8_t frame[280];
+    size_t frame_len = build_v1_frame(frame, 255);
+    TEST_ASSERT_EQUAL(263, frame_len);  /* 6 + 255 + 2 */
+
+    mavlink_parser_t p;
+    mavlink_parser_init(&p);
+
+    mavlink_parser_result_t res = feed_bytes(&p, frame, frame_len);
+    TEST_ASSERT_EQUAL(MAVLINK_PARSER_COMPLETE, res);
+
+    const uint8_t *out;
+    size_t out_len;
+    mavlink_parser_get_frame(&p, &out, &out_len);
+    TEST_ASSERT_EQUAL(frame_len, out_len);
+}
+
+/* ── v2 frame tests ──────────────────────────────────────────── */
+
+TEST_CASE("parse v2 frame with zero-length payload", "[mavlink_parser]")
+{
+    uint8_t frame[16];
+    size_t frame_len = build_v2_frame(frame, 0);
+    TEST_ASSERT_EQUAL(12, frame_len);  /* header(10) + ck(2) */
+
+    mavlink_parser_t p;
+    mavlink_parser_init(&p);
+
+    mavlink_parser_result_t res = feed_bytes(&p, frame, frame_len);
+    TEST_ASSERT_EQUAL(MAVLINK_PARSER_COMPLETE, res);
+
+    const uint8_t *out;
+    size_t out_len;
+    mavlink_parser_get_frame(&p, &out, &out_len);
+    TEST_ASSERT_EQUAL(frame_len, out_len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(frame, out, frame_len);
+}
+
+TEST_CASE("parse v2 frame with 10-byte payload", "[mavlink_parser]")
+{
+    uint8_t frame[32];
+    size_t frame_len = build_v2_frame(frame, 10);
+    TEST_ASSERT_EQUAL(22, frame_len);
+
+    mavlink_parser_t p;
+    mavlink_parser_init(&p);
+
+    mavlink_parser_result_t res = feed_bytes(&p, frame, frame_len);
+    TEST_ASSERT_EQUAL(MAVLINK_PARSER_COMPLETE, res);
+
+    const uint8_t *out;
+    size_t out_len;
+    mavlink_parser_get_frame(&p, &out, &out_len);
+    TEST_ASSERT_EQUAL(frame_len, out_len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(frame, out, frame_len);
+}
+
+/* ── v2 signed frame tests ───────────────────────────────────── */
+
+TEST_CASE("parse v2 signed frame with zero payload", "[mavlink_parser]")
+{
+    uint8_t frame[32];
+    size_t frame_len = build_v2_signed_frame(frame, 0);
+    TEST_ASSERT_EQUAL(25, frame_len);  /* 10 + 0 + 2 + 13 */
+
+    mavlink_parser_t p;
+    mavlink_parser_init(&p);
+
+    mavlink_parser_result_t res = feed_bytes(&p, frame, frame_len);
+    TEST_ASSERT_EQUAL(MAVLINK_PARSER_COMPLETE, res);
+
+    const uint8_t *out;
+    size_t out_len;
+    mavlink_parser_get_frame(&p, &out, &out_len);
+    TEST_ASSERT_EQUAL(frame_len, out_len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(frame, out, frame_len);
+}
+
+TEST_CASE("parse v2 signed frame with 5-byte payload", "[mavlink_parser]")
+{
+    uint8_t frame[48];
+    size_t frame_len = build_v2_signed_frame(frame, 5);
+    TEST_ASSERT_EQUAL(30, frame_len);  /* 10 + 5 + 2 + 13 */
+
+    mavlink_parser_t p;
+    mavlink_parser_init(&p);
+
+    mavlink_parser_result_t res = feed_bytes(&p, frame, frame_len);
+    TEST_ASSERT_EQUAL(MAVLINK_PARSER_COMPLETE, res);
+
+    const uint8_t *out;
+    size_t out_len;
+    mavlink_parser_get_frame(&p, &out, &out_len);
+    TEST_ASSERT_EQUAL(frame_len, out_len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(frame, out, frame_len);
+}
+
+/* ── garbage / resync tests ──────────────────────────────────── */
+
+TEST_CASE("parser ignores leading garbage bytes", "[mavlink_parser]")
+{
+    uint8_t garbage[] = {0x00, 0x42, 0xFF, 0x13, 0x37};
+    uint8_t frame[16];
+    size_t frame_len = build_v1_frame(frame, 2);
+
+    mavlink_parser_t p;
+    mavlink_parser_init(&p);
+
+    /* Feed garbage first — all should return INCOMPLETE. */
+    for (size_t i = 0; i < sizeof(garbage); i++) {
+        TEST_ASSERT_EQUAL(MAVLINK_PARSER_INCOMPLETE,
+                          mavlink_parser_parse_byte(&p, garbage[i]));
+    }
+
+    /* Now feed the real frame. */
+    mavlink_parser_result_t res = feed_bytes(&p, frame, frame_len);
+    TEST_ASSERT_EQUAL(MAVLINK_PARSER_COMPLETE, res);
+
+    const uint8_t *out;
+    size_t out_len;
+    mavlink_parser_get_frame(&p, &out, &out_len);
+    TEST_ASSERT_EQUAL(frame_len, out_len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(frame, out, frame_len);
+}
+
+TEST_CASE("parser resyncs after init on new frame", "[mavlink_parser]")
+{
+    /* Start a v1 frame but don't finish it, then re-init and start fresh. */
+    mavlink_parser_t p;
+    mavlink_parser_init(&p);
+
+    uint8_t partial[] = {MAVLINK_V1_STX, 0x04, 0x00};
+    for (size_t i = 0; i < sizeof(partial); i++) {
+        mavlink_parser_parse_byte(&p, partial[i]);
+    }
+
+    /* Reinit (simulates reset after timeout). */
+    mavlink_parser_init(&p);
+    TEST_ASSERT_EQUAL(MAVLINK_PARSE_IDLE, p.state);
+
+    /* Now a complete frame should parse cleanly. */
+    uint8_t frame[16];
+    size_t frame_len = build_v2_frame(frame, 1);
+
+    mavlink_parser_result_t res = feed_bytes(&p, frame, frame_len);
+    TEST_ASSERT_EQUAL(MAVLINK_PARSER_COMPLETE, res);
+
+    const uint8_t *out;
+    size_t out_len;
+    mavlink_parser_get_frame(&p, &out, &out_len);
+    TEST_ASSERT_EQUAL(frame_len, out_len);
+}
+
+/* ── back-to-back frame tests ────────────────────────────────── */
+
+TEST_CASE("parse two back-to-back v1 frames", "[mavlink_parser]")
+{
+    uint8_t frame1[16], frame2[16];
+    size_t len1 = build_v1_frame(frame1, 2);
+    size_t len2 = build_v1_frame(frame2, 3);
+
+    /* Concatenate both frames. */
+    uint8_t stream[32];
+    memcpy(stream, frame1, len1);
+    memcpy(stream + len1, frame2, len2);
+    size_t total = len1 + len2;
+
+    mavlink_parser_t p;
+    mavlink_parser_init(&p);
+
+    /* Parse first frame. */
+    size_t i = 0;
+    while (i < total) {
+        mavlink_parser_result_t res =
+            mavlink_parser_parse_byte(&p, stream[i++]);
+        if (res == MAVLINK_PARSER_COMPLETE) {
+            const uint8_t *out;
+            size_t out_len;
+            mavlink_parser_get_frame(&p, &out, &out_len);
+            TEST_ASSERT_EQUAL(len1, out_len);
+            TEST_ASSERT_EQUAL_UINT8_ARRAY(frame1, out, len1);
+            mavlink_parser_init(&p);
+            break;
+        }
+    }
+
+    /* Parse second frame. */
+    while (i < total) {
+        mavlink_parser_result_t res =
+            mavlink_parser_parse_byte(&p, stream[i++]);
+        if (res == MAVLINK_PARSER_COMPLETE) {
+            const uint8_t *out;
+            size_t out_len;
+            mavlink_parser_get_frame(&p, &out, &out_len);
+            TEST_ASSERT_EQUAL(len2, out_len);
+            TEST_ASSERT_EQUAL_UINT8_ARRAY(frame2, out, len2);
+            return;
+        }
+    }
+
+    TEST_FAIL_MESSAGE("Second frame was not completed");
+}
+
+TEST_CASE("parse mixed v1 and v2 back-to-back", "[mavlink_parser]")
+{
+    uint8_t frame1[16], frame2[32];
+    size_t len1 = build_v1_frame(frame1, 1);
+    size_t len2 = build_v2_frame(frame2, 3);
+
+    uint8_t stream[48];
+    memcpy(stream, frame1, len1);
+    memcpy(stream + len1, frame2, len2);
+    size_t total = len1 + len2;
+
+    mavlink_parser_t p;
+    mavlink_parser_init(&p);
+
+    int frames_found = 0;
+    for (size_t i = 0; i < total; i++) {
+        mavlink_parser_result_t res =
+            mavlink_parser_parse_byte(&p, stream[i]);
+        if (res == MAVLINK_PARSER_COMPLETE) {
+            frames_found++;
+            mavlink_parser_init(&p);
+        }
+    }
+
+    TEST_ASSERT_EQUAL(2, frames_found);
+}
+
+/* ── get_frame content tests ─────────────────────────────────── */
+
+TEST_CASE("get_frame returns correct v2 content", "[mavlink_parser]")
+{
+    uint8_t frame[32];
+    size_t frame_len = build_v2_frame(frame, 3);
+
+    mavlink_parser_t p;
+    mavlink_parser_init(&p);
+    feed_bytes(&p, frame, frame_len);
+
+    const uint8_t *out;
+    size_t out_len;
+    mavlink_parser_get_frame(&p, &out, &out_len);
+
+    /* Verify STX */
+    TEST_ASSERT_EQUAL_HEX8(MAVLINK_V2_STX, out[0]);
+    /* Verify payload length byte */
+    TEST_ASSERT_EQUAL(3, out[1]);
+    /* Verify payload content (bytes 0, 1, 2) */
+    TEST_ASSERT_EQUAL(0, out[10]);
+    TEST_ASSERT_EQUAL(1, out[11]);
+    TEST_ASSERT_EQUAL(2, out[12]);
+    /* Verify checksum bytes */
+    TEST_ASSERT_EQUAL_HEX8(0xCC, out[13]);
+    TEST_ASSERT_EQUAL_HEX8(0xDD, out[14]);
+}

--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "main.c"
     INCLUDE_DIRS "."
-    PRIV_REQUIRES micro_ros_espidf_component
+    PRIV_REQUIRES micro_ros_espidf_component mavlink_bridge
 )

--- a/firmware/main/main.c
+++ b/firmware/main/main.c
@@ -15,6 +15,8 @@
 #include <rmw_microxrcedds_c/config.h>
 #include <uros_network_interfaces.h>
 
+#include "mavlink_bridge.h"
+
 static const char *TAG = "drone_onboard";
 
 /* DESIGN: abort on micro-ROS init errors (same philosophy as ESP_ERROR_CHECK) */
@@ -68,11 +70,15 @@ static void micro_ros_task(void *arg)
     RCCHECK(rclc_node_init_default(&node, node_name, ns, &support));
     ESP_LOGI(TAG, "node '%s/%s' created", ns, node_name);
 
-    /* DESIGN: executor handles = 0 for scaffold; will grow as publishers/
-       subscriptions are added in subsequent PRs (ToF, camera, MAVLink) */
-    const unsigned int num_handles = 1;
+    /* Executor handles: MAVLink subscriber (1).  Will grow as ToF and
+       camera publishers are added in subsequent PRs. */
+    const unsigned int num_handles = MAVLINK_BRIDGE_NUM_HANDLES;
     RCCHECK(
         rclc_executor_init(&executor, &support.context, num_handles, &allocator));
+
+    /* MAVLink serial bridge (UART ↔ micro-ROS) */
+    RCCHECK(mavlink_bridge_create(&node, &executor));
+    RCCHECK(mavlink_bridge_start());
 
     ESP_LOGI(TAG, "spinning...");
     while (true) {
@@ -103,6 +109,10 @@ void app_main(void)
        (SSID/password set in menuconfig, not hardcoded). Will be replaced
        by custom WiFi mesh component when multi-drone networking is added. */
     ESP_ERROR_CHECK(uros_network_interface_initialize());
+
+    /* MAVLink UART must be ready before the micro-ROS task creates the
+       publisher/subscriber that uses it. */
+    ESP_ERROR_CHECK(mavlink_bridge_init());
 
     /* DESIGN: 16KB stack for micro-ROS task; sufficient for node + executor.
        Will need increase when ToF/camera publishers are added. */

--- a/firmware/test/test_mavlink_parser_host.c
+++ b/firmware/test/test_mavlink_parser_host.c
@@ -1,0 +1,257 @@
+/* Host-compilable test for the MAVLink frame parser.
+   Compile: cc -o test_mavlink_parser test_mavlink_parser_host.c \
+                ../components/mavlink_bridge/mavlink_parser.c \
+                -I../components/mavlink_bridge/include
+   Run:     ./test_mavlink_parser                                        */
+
+#include "mavlink_parser.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static int tests_run  = 0;
+static int tests_pass = 0;
+
+#define RUN(name)                                                              \
+    do {                                                                       \
+        tests_run++;                                                           \
+        printf("  %-50s ", #name);                                             \
+        name();                                                                \
+        tests_pass++;                                                          \
+        printf("PASS\n");                                                      \
+    } while (0)
+
+/* ── helpers ─────────────────────────────────────────────────── */
+
+static mavlink_parser_result_t feed(mavlink_parser_t *p,
+                                    const uint8_t *data, size_t len)
+{
+    mavlink_parser_result_t res = MAVLINK_PARSER_INCOMPLETE;
+    for (size_t i = 0; i < len; i++) {
+        res = mavlink_parser_parse_byte(p, data[i]);
+    }
+    return res;
+}
+
+static size_t build_v1(uint8_t *buf, uint8_t plen)
+{
+    size_t i = 0;
+    buf[i++] = 0xFE; buf[i++] = plen;
+    buf[i++] = 0; buf[i++] = 1; buf[i++] = 1; buf[i++] = 0;
+    for (uint8_t j = 0; j < plen; j++) buf[i++] = j;
+    buf[i++] = 0xAA; buf[i++] = 0xBB;
+    return i;
+}
+
+static size_t build_v2(uint8_t *buf, uint8_t plen)
+{
+    size_t i = 0;
+    buf[i++] = 0xFD; buf[i++] = plen;
+    buf[i++] = 0; buf[i++] = 0; buf[i++] = 0;
+    buf[i++] = 1; buf[i++] = 1;
+    buf[i++] = 0; buf[i++] = 0; buf[i++] = 0;
+    for (uint8_t j = 0; j < plen; j++) buf[i++] = j;
+    buf[i++] = 0xCC; buf[i++] = 0xDD;
+    return i;
+}
+
+static size_t build_v2_signed(uint8_t *buf, uint8_t plen)
+{
+    size_t i = 0;
+    buf[i++] = 0xFD; buf[i++] = plen;
+    buf[i++] = 0x01; buf[i++] = 0; buf[i++] = 0;
+    buf[i++] = 1; buf[i++] = 1;
+    buf[i++] = 0; buf[i++] = 0; buf[i++] = 0;
+    for (uint8_t j = 0; j < plen; j++) buf[i++] = j;
+    buf[i++] = 0xEE; buf[i++] = 0xFF;
+    for (int j = 0; j < 13; j++) buf[i++] = (uint8_t)(0x50 + j);
+    return i;
+}
+
+/* ── tests ───────────────────────────────────────────────────── */
+
+static void test_init(void)
+{
+    mavlink_parser_t p;
+    mavlink_parser_init(&p);
+    assert(p.state == MAVLINK_PARSE_IDLE);
+    assert(p.idx == 0);
+}
+
+static void test_v1_empty_payload(void)
+{
+    uint8_t f[16]; size_t fl = build_v1(f, 0);
+    assert(fl == 8);
+    mavlink_parser_t p; mavlink_parser_init(&p);
+    assert(feed(&p, f, fl) == MAVLINK_PARSER_COMPLETE);
+    const uint8_t *o; size_t ol;
+    mavlink_parser_get_frame(&p, &o, &ol);
+    assert(ol == fl);
+    assert(memcmp(f, o, fl) == 0);
+}
+
+static void test_v1_payload(void)
+{
+    uint8_t f[32]; size_t fl = build_v1(f, 4);
+    assert(fl == 12);
+    mavlink_parser_t p; mavlink_parser_init(&p);
+    assert(feed(&p, f, fl) == MAVLINK_PARSER_COMPLETE);
+    const uint8_t *o; size_t ol;
+    mavlink_parser_get_frame(&p, &o, &ol);
+    assert(ol == fl);
+}
+
+static void test_v1_max_payload(void)
+{
+    uint8_t f[280]; size_t fl = build_v1(f, 255);
+    assert(fl == 263);
+    mavlink_parser_t p; mavlink_parser_init(&p);
+    assert(feed(&p, f, fl) == MAVLINK_PARSER_COMPLETE);
+    const uint8_t *o; size_t ol;
+    mavlink_parser_get_frame(&p, &o, &ol);
+    assert(ol == fl);
+}
+
+static void test_v2_empty_payload(void)
+{
+    uint8_t f[16]; size_t fl = build_v2(f, 0);
+    assert(fl == 12);
+    mavlink_parser_t p; mavlink_parser_init(&p);
+    assert(feed(&p, f, fl) == MAVLINK_PARSER_COMPLETE);
+    const uint8_t *o; size_t ol;
+    mavlink_parser_get_frame(&p, &o, &ol);
+    assert(ol == fl);
+}
+
+static void test_v2_payload(void)
+{
+    uint8_t f[32]; size_t fl = build_v2(f, 10);
+    assert(fl == 22);
+    mavlink_parser_t p; mavlink_parser_init(&p);
+    assert(feed(&p, f, fl) == MAVLINK_PARSER_COMPLETE);
+    const uint8_t *o; size_t ol;
+    mavlink_parser_get_frame(&p, &o, &ol);
+    assert(ol == fl);
+    assert(memcmp(f, o, fl) == 0);
+}
+
+static void test_v2_signed_empty(void)
+{
+    uint8_t f[32]; size_t fl = build_v2_signed(f, 0);
+    assert(fl == 25);
+    mavlink_parser_t p; mavlink_parser_init(&p);
+    assert(feed(&p, f, fl) == MAVLINK_PARSER_COMPLETE);
+    const uint8_t *o; size_t ol;
+    mavlink_parser_get_frame(&p, &o, &ol);
+    assert(ol == fl);
+}
+
+static void test_v2_signed_payload(void)
+{
+    uint8_t f[48]; size_t fl = build_v2_signed(f, 5);
+    assert(fl == 30);
+    mavlink_parser_t p; mavlink_parser_init(&p);
+    assert(feed(&p, f, fl) == MAVLINK_PARSER_COMPLETE);
+    const uint8_t *o; size_t ol;
+    mavlink_parser_get_frame(&p, &o, &ol);
+    assert(ol == fl);
+    assert(memcmp(f, o, fl) == 0);
+}
+
+static void test_garbage_before_frame(void)
+{
+    uint8_t garbage[] = {0x00, 0x42, 0xFF, 0x13, 0x37};
+    uint8_t f[16]; size_t fl = build_v1(f, 2);
+    mavlink_parser_t p; mavlink_parser_init(&p);
+    assert(feed(&p, garbage, sizeof(garbage)) == MAVLINK_PARSER_INCOMPLETE);
+    assert(feed(&p, f, fl) == MAVLINK_PARSER_COMPLETE);
+    const uint8_t *o; size_t ol;
+    mavlink_parser_get_frame(&p, &o, &ol);
+    assert(ol == fl);
+    assert(memcmp(f, o, fl) == 0);
+}
+
+static void test_back_to_back_v1(void)
+{
+    uint8_t f1[16], f2[16];
+    size_t l1 = build_v1(f1, 2), l2 = build_v1(f2, 3);
+    uint8_t stream[32];
+    memcpy(stream, f1, l1);
+    memcpy(stream + l1, f2, l2);
+
+    mavlink_parser_t p; mavlink_parser_init(&p);
+    int found = 0;
+    for (size_t i = 0; i < l1 + l2; i++) {
+        if (mavlink_parser_parse_byte(&p, stream[i]) == MAVLINK_PARSER_COMPLETE) {
+            found++;
+            mavlink_parser_init(&p);
+        }
+    }
+    assert(found == 2);
+}
+
+static void test_back_to_back_mixed(void)
+{
+    uint8_t f1[16], f2[32];
+    size_t l1 = build_v1(f1, 1), l2 = build_v2(f2, 3);
+    uint8_t stream[48];
+    memcpy(stream, f1, l1);
+    memcpy(stream + l1, f2, l2);
+
+    mavlink_parser_t p; mavlink_parser_init(&p);
+    int found = 0;
+    for (size_t i = 0; i < l1 + l2; i++) {
+        if (mavlink_parser_parse_byte(&p, stream[i]) == MAVLINK_PARSER_COMPLETE) {
+            found++;
+            mavlink_parser_init(&p);
+        }
+    }
+    assert(found == 2);
+}
+
+static void test_frame_content(void)
+{
+    uint8_t f[32]; size_t fl = build_v2(f, 3);
+    mavlink_parser_t p; mavlink_parser_init(&p);
+    feed(&p, f, fl);
+    const uint8_t *o; size_t ol;
+    mavlink_parser_get_frame(&p, &o, &ol);
+    assert(o[0] == 0xFD);
+    assert(o[1] == 3);
+    assert(o[10] == 0 && o[11] == 1 && o[12] == 2);
+    assert(o[13] == 0xCC && o[14] == 0xDD);
+}
+
+static void test_incomplete_does_not_complete(void)
+{
+    mavlink_parser_t p; mavlink_parser_init(&p);
+    /* Feed only 3 bytes of a v2 frame with 10-byte payload (needs 22 total) */
+    uint8_t partial[] = {0xFD, 10, 0x00};
+    assert(feed(&p, partial, sizeof(partial)) == MAVLINK_PARSER_INCOMPLETE);
+    assert(p.state == MAVLINK_PARSE_ACCUMULATING);
+}
+
+/* ── main ────────────────────────────────────────────────────── */
+
+int main(void)
+{
+    printf("MAVLink parser host tests\n");
+
+    RUN(test_init);
+    RUN(test_v1_empty_payload);
+    RUN(test_v1_payload);
+    RUN(test_v1_max_payload);
+    RUN(test_v2_empty_payload);
+    RUN(test_v2_payload);
+    RUN(test_v2_signed_empty);
+    RUN(test_v2_signed_payload);
+    RUN(test_garbage_before_frame);
+    RUN(test_back_to_back_v1);
+    RUN(test_back_to_back_mixed);
+    RUN(test_frame_content);
+    RUN(test_incomplete_does_not_complete);
+
+    printf("\n%d/%d tests passed\n", tests_pass, tests_run);
+    return tests_pass == tests_run ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Implements the MAVLink serial bridge component for the XIAO ESP32S3 firmware, bridging MAVLink frames between the H743 flight controller (UART) and the ground station (micro-ROS topics).

Closes #4

**Depends on:** #22 (feat/issue-1 — ESP-IDF scaffold, merged into this branch)

## What changed

- **`mavlink_parser`** — Lightweight MAVLink v1/v2 frame detection state machine. Pure C with zero ESP-IDF dependencies for easy host-side testing. Supports v2 signature detection (incompat_flags bit 0).

- **`mavlink_bridge`** — ESP-IDF component that:
  - Initializes UART (configurable via Kconfig, defaults: GPIO21 TX, GPIO20 RX, 921600 baud per `hardware_wiring.md`)
  - Creates a micro-ROS publisher on `mavlink/from_fc` (FC → ground) and subscriber on `mavlink/to_fc` (ground → FC)
  - Runs a FreeRTOS task that reads UART bytes, parses MAVLink frames, and publishes them
  - Forwards received micro-ROS messages to UART in the subscriber callback

- **Message type:** `std_msgs/UInt8MultiArray` with static allocation (no heap, avoids fragmentation on ESP32)

- **Integration:** Updated `main.c` to init UART before the micro-ROS task, then create and start the bridge within the executor

## Files

| File | Description |
|------|-------------|
| `firmware/components/mavlink_bridge/include/mavlink_parser.h` | Parser API (no ESP-IDF deps) |
| `firmware/components/mavlink_bridge/mavlink_parser.c` | Frame detection state machine |
| `firmware/components/mavlink_bridge/include/mavlink_bridge.h` | Bridge public API |
| `firmware/components/mavlink_bridge/mavlink_bridge.c` | UART + micro-ROS integration |
| `firmware/components/mavlink_bridge/CMakeLists.txt` | Component build config |
| `firmware/components/mavlink_bridge/Kconfig` | UART pin/baud configuration |
| `firmware/components/mavlink_bridge/test/test_mavlink_parser.c` | Unity component tests (13 tests) |
| `firmware/test/test_mavlink_parser_host.c` | Host-compilable tests (13 tests) |
| `firmware/main/main.c` | Integrated bridge init/create/start |
| `firmware/main/CMakeLists.txt` | Added mavlink_bridge dependency |

## Test plan

- [x] 13 host parser tests pass (`cc` + `./test_mavlink_parser`)
- [ ] ESP-IDF firmware build succeeds (CI)
- [ ] Unity component tests compile via `idf.py build -T test` (CI)
- [ ] cppcheck passes on firmware code (CI)