### PR TITLE
feat(firmware): implement OV2640 camera driver component

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -6,3 +6,7 @@ set(EXTRA_COMPONENT_DIRS
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(drone_swarm_firmware)
+
+# DESIGN: micro-ROS libmicroros.a provides __atomic_*_8 symbols that conflict
+# with ESP-IDF newlib on v5.3+. Allow multiple definitions to resolve the clash.
+idf_build_set_property(LINK_OPTIONS "-Wl,--allow-multiple-definition" APPEND)

--- a/firmware/components/ov2640/CMakeLists.txt
+++ b/firmware/components/ov2640/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "ov2640.c"
+    INCLUDE_DIRS "include"
+    PRIV_REQUIRES esp32-camera
+)

--- a/firmware/components/ov2640/Kconfig
+++ b/firmware/components/ov2640/Kconfig
@@ -1,0 +1,41 @@
+menu "OV2640 Camera Driver"
+
+    config OV2640_JPEG_QUALITY
+        int "JPEG quality (0-63, lower is better)"
+        default 12
+        range 0 63
+        help
+            JPEG compression quality. Lower values produce higher quality
+            images but larger file sizes. 12 is a good balance for
+            compressed image streaming over micro-ROS UDP transport.
+
+    choice OV2640_FRAME_SIZE
+        prompt "Frame resolution"
+        default OV2640_FRAME_SIZE_QVGA
+        help
+            Camera capture resolution. Smaller resolutions reduce JPEG
+            size and micro-ROS transport bandwidth. QVGA is the default
+            as this camera is supplementary (NOT the primary SLAM sensor).
+
+        config OV2640_FRAME_SIZE_QQVGA
+            bool "QQVGA (160x120)"
+        config OV2640_FRAME_SIZE_QVGA
+            bool "QVGA (320x240)"
+        config OV2640_FRAME_SIZE_CIF
+            bool "CIF (400x296)"
+        config OV2640_FRAME_SIZE_VGA
+            bool "VGA (640x480)"
+        config OV2640_FRAME_SIZE_SVGA
+            bool "SVGA (800x600)"
+    endchoice
+
+    config OV2640_FB_COUNT
+        int "Frame buffer count"
+        default 2
+        range 1 3
+        help
+            Number of frame buffers in PSRAM. 2 enables double-buffering
+            so capture continues while the previous frame is transmitted.
+            More buffers use more PSRAM but reduce frame drops.
+
+endmenu

--- a/firmware/components/ov2640/idf_component.yml
+++ b/firmware/components/ov2640/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+  espressif/esp32-camera: ">=2.0.0"

--- a/firmware/components/ov2640/include/ov2640.h
+++ b/firmware/components/ov2640/include/ov2640.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "esp_err.h"
+
+/**
+ * JPEG frame captured from the OV2640 camera.
+ * Valid until ov2640_release() is called.
+ */
+typedef struct {
+    const uint8_t *buf;   /**< Pointer to JPEG data */
+    size_t len;           /**< JPEG data length in bytes */
+} ov2640_frame_t;
+
+/**
+ * Initialize the OV2640 camera on XIAO ESP32S3 Sense.
+ *
+ * Uses Kconfig settings for resolution, JPEG quality, and buffer count.
+ * Must be called once before ov2640_capture().
+ *
+ * @return ESP_OK on success.
+ */
+esp_err_t ov2640_init(void);
+
+/**
+ * Capture a single JPEG frame.
+ *
+ * Only one frame can be held at a time. Call ov2640_release() before
+ * capturing the next frame.
+ *
+ * @param[out] frame  Filled with JPEG data pointer and length on success.
+ * @return ESP_OK on success, ESP_FAIL on capture failure.
+ */
+esp_err_t ov2640_capture(ov2640_frame_t *frame);
+
+/**
+ * Release the current frame buffer back to the camera driver.
+ */
+void ov2640_release(void);

--- a/firmware/components/ov2640/ov2640.c
+++ b/firmware/components/ov2640/ov2640.c
@@ -1,0 +1,125 @@
+#include "ov2640.h"
+
+#include "esp_camera.h"
+#include "esp_log.h"
+
+static const char *TAG = "ov2640";
+
+/* XIAO ESP32S3 Sense camera expansion board pin mapping.
+   These are fixed by the Sense expansion board PCB — not configurable. */
+#define CAM_PIN_PWDN    (-1)
+#define CAM_PIN_RESET   (-1)
+#define CAM_PIN_XCLK    10
+#define CAM_PIN_SIOD    40
+#define CAM_PIN_SIOC    39
+#define CAM_PIN_D7      48
+#define CAM_PIN_D6      11
+#define CAM_PIN_D5      12
+#define CAM_PIN_D4      14
+#define CAM_PIN_D3      16
+#define CAM_PIN_D2      18
+#define CAM_PIN_D1      17
+#define CAM_PIN_D0      15
+#define CAM_PIN_VSYNC   38
+#define CAM_PIN_HREF    47
+#define CAM_PIN_PCLK    13
+
+/* Map Kconfig choice to esp_camera framesize_t */
+#if defined(CONFIG_OV2640_FRAME_SIZE_QQVGA)
+#define OV2640_FRAME_SIZE  FRAMESIZE_QQVGA
+#elif defined(CONFIG_OV2640_FRAME_SIZE_QVGA)
+#define OV2640_FRAME_SIZE  FRAMESIZE_QVGA
+#elif defined(CONFIG_OV2640_FRAME_SIZE_CIF)
+#define OV2640_FRAME_SIZE  FRAMESIZE_CIF
+#elif defined(CONFIG_OV2640_FRAME_SIZE_VGA)
+#define OV2640_FRAME_SIZE  FRAMESIZE_VGA
+#elif defined(CONFIG_OV2640_FRAME_SIZE_SVGA)
+#define OV2640_FRAME_SIZE  FRAMESIZE_SVGA
+#else
+#define OV2640_FRAME_SIZE  FRAMESIZE_QVGA
+#endif
+
+/* Current frame held by the caller (one-at-a-time) */
+static camera_fb_t *s_current_fb;
+
+esp_err_t ov2640_init(void)
+{
+    camera_config_t config = {
+        .pin_pwdn = CAM_PIN_PWDN,
+        .pin_reset = CAM_PIN_RESET,
+        .pin_xclk = CAM_PIN_XCLK,
+        .pin_sccb_sda = CAM_PIN_SIOD,
+        .pin_sccb_scl = CAM_PIN_SIOC,
+        .pin_d7 = CAM_PIN_D7,
+        .pin_d6 = CAM_PIN_D6,
+        .pin_d5 = CAM_PIN_D5,
+        .pin_d4 = CAM_PIN_D4,
+        .pin_d3 = CAM_PIN_D3,
+        .pin_d2 = CAM_PIN_D2,
+        .pin_d1 = CAM_PIN_D1,
+        .pin_d0 = CAM_PIN_D0,
+        .pin_vsync = CAM_PIN_VSYNC,
+        .pin_href = CAM_PIN_HREF,
+        .pin_pclk = CAM_PIN_PCLK,
+
+        .xclk_freq_hz = 20000000,
+        .ledc_timer = LEDC_TIMER_0,
+        .ledc_channel = LEDC_CHANNEL_0,
+
+        .pixel_format = PIXFORMAT_JPEG,
+        .frame_size = OV2640_FRAME_SIZE,
+        .jpeg_quality = CONFIG_OV2640_JPEG_QUALITY,
+        .fb_count = CONFIG_OV2640_FB_COUNT,
+        .fb_location = CAMERA_FB_IN_PSRAM,
+        /* DESIGN: GRAB_LATEST with multiple buffers ensures the publisher
+           always gets the freshest frame, dropping stale ones */
+        .grab_mode = (CONFIG_OV2640_FB_COUNT > 1) ? CAMERA_GRAB_LATEST
+                                                   : CAMERA_GRAB_WHEN_EMPTY,
+    };
+
+    esp_err_t err = esp_camera_init(&config);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "init failed: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    ESP_LOGI(TAG, "initialized (quality=%d, frame_size=%d, fb_count=%d)",
+             CONFIG_OV2640_JPEG_QUALITY, (int)OV2640_FRAME_SIZE,
+             CONFIG_OV2640_FB_COUNT);
+    return ESP_OK;
+}
+
+esp_err_t ov2640_capture(ov2640_frame_t *frame)
+{
+    if (s_current_fb != NULL) {
+        ESP_LOGW(TAG, "previous frame not released, releasing now");
+        esp_camera_fb_return(s_current_fb);
+        s_current_fb = NULL;
+    }
+
+    s_current_fb = esp_camera_fb_get();
+    if (s_current_fb == NULL) {
+        ESP_LOGW(TAG, "capture failed");
+        return ESP_FAIL;
+    }
+
+    if (s_current_fb->format != PIXFORMAT_JPEG) {
+        ESP_LOGE(TAG, "unexpected format %d, expected JPEG",
+                 s_current_fb->format);
+        esp_camera_fb_return(s_current_fb);
+        s_current_fb = NULL;
+        return ESP_FAIL;
+    }
+
+    frame->buf = s_current_fb->buf;
+    frame->len = s_current_fb->len;
+    return ESP_OK;
+}
+
+void ov2640_release(void)
+{
+    if (s_current_fb != NULL) {
+        esp_camera_fb_return(s_current_fb);
+        s_current_fb = NULL;
+    }
+}

--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "main.c"
     INCLUDE_DIRS "."
-    PRIV_REQUIRES micro_ros_espidf_component mavlink_bridge
+    PRIV_REQUIRES micro_ros_espidf_component mavlink_bridge ov2640 esp_timer
 )

--- a/firmware/main/main.c
+++ b/firmware/main/main.c
@@ -1,8 +1,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_system.h"
+#include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "nvs_flash.h"
@@ -13,9 +15,12 @@
 #include <rclc/executor.h>
 #include <rmw_microros/rmw_microros.h>
 #include <rmw_microxrcedds_c/config.h>
+#include <rosidl_runtime_c/string_functions.h>
+#include <sensor_msgs/msg/compressed_image.h>
 #include <uros_network_interfaces.h>
 
 #include "mavlink_bridge.h"
+#include "ov2640.h"
 
 static const char *TAG = "drone_onboard";
 
@@ -39,6 +44,43 @@ static const char *TAG = "drone_onboard";
                      __LINE__);                                                \
         }                                                                      \
     } while (0)
+
+/* DESIGN: 64KB JPEG buffer covers QVGA/CIF typical output.
+   Allocated in PSRAM to preserve internal SRAM for stack/heap. */
+#define CAMERA_JPEG_BUF_SIZE (64 * 1024)
+
+static rcl_publisher_t camera_pub;
+static sensor_msgs__msg__CompressedImage camera_msg;
+
+static void camera_timer_cb(rcl_timer_t *timer, int64_t last_call_time)
+{
+    (void)last_call_time;
+    if (timer == NULL) {
+        return;
+    }
+
+    ov2640_frame_t frame;
+    if (ov2640_capture(&frame) != ESP_OK) {
+        return;
+    }
+
+    if (frame.len <= camera_msg.data.capacity) {
+        memcpy(camera_msg.data.data, frame.buf, frame.len);
+        camera_msg.data.size = frame.len;
+
+        int64_t now_us = esp_timer_get_time();
+        camera_msg.header.stamp.sec = (int32_t)(now_us / 1000000);
+        camera_msg.header.stamp.nanosec =
+            (uint32_t)((now_us % 1000000) * 1000);
+
+        RCSOFTCHECK(rcl_publish(&camera_pub, &camera_msg, NULL));
+    } else {
+        ESP_LOGW(TAG, "JPEG too large (%u > %u)", (unsigned)frame.len,
+                 (unsigned)camera_msg.data.capacity);
+    }
+
+    ov2640_release();
+}
 
 static void micro_ros_task(void *arg)
 {
@@ -70,11 +112,38 @@ static void micro_ros_task(void *arg)
     RCCHECK(rclc_node_init_default(&node, node_name, ns, &support));
     ESP_LOGI(TAG, "node '%s/%s' created", ns, node_name);
 
-    /* Executor handles: MAVLink subscriber (1).  Will grow as ToF and
-       camera publishers are added in subsequent PRs. */
-    const unsigned int num_handles = MAVLINK_BRIDGE_NUM_HANDLES;
+    /* --- Camera publisher (best-effort QoS for sensor data) --- */
+    RCCHECK(rclc_publisher_init_best_effort(
+        &camera_pub, &node,
+        ROSIDL_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, CompressedImage),
+        "camera/compressed"));
+
+    /* Pre-allocate CompressedImage message fields */
+    char frame_id[32];
+    snprintf(frame_id, sizeof(frame_id), "drone_%d_camera", CONFIG_DRONE_ID);
+    rosidl_runtime_c__String__assign(&camera_msg.header.frame_id, frame_id);
+    rosidl_runtime_c__String__assign(&camera_msg.format, "jpeg");
+
+    camera_msg.data.data =
+        (uint8_t *)heap_caps_malloc(CAMERA_JPEG_BUF_SIZE, MALLOC_CAP_SPIRAM);
+    if (camera_msg.data.data == NULL) {
+        ESP_LOGE(TAG, "failed to allocate JPEG buffer in PSRAM");
+        vTaskDelete(NULL);
+    }
+    camera_msg.data.capacity = CAMERA_JPEG_BUF_SIZE;
+    camera_msg.data.size = 0;
+
+    /* --- Camera timer (10 Hz = 100 ms per CLAUDE.md spec) --- */
+    rcl_timer_t camera_timer;
+    RCCHECK(rclc_timer_init_default(&camera_timer, &support,
+                                    RCL_MS_TO_NS(100), camera_timer_cb));
+
+    /* Executor handles: camera timer (1) + MAVLink subscriber.
+       Will grow as ToF publisher is added. */
+    const unsigned int num_handles = 1 + MAVLINK_BRIDGE_NUM_HANDLES;
     RCCHECK(
         rclc_executor_init(&executor, &support.context, num_handles, &allocator));
+    RCCHECK(rclc_executor_add_timer(&executor, &camera_timer));
 
     /* MAVLink serial bridge (UART ↔ micro-ROS) */
     RCCHECK(mavlink_bridge_create(&node, &executor));
@@ -114,7 +183,10 @@ void app_main(void)
        publisher/subscriber that uses it. */
     ESP_ERROR_CHECK(mavlink_bridge_init());
 
-    /* DESIGN: 16KB stack for micro-ROS task; sufficient for node + executor.
-       Will need increase when ToF/camera publishers are added. */
-    xTaskCreate(micro_ros_task, "uros", 16384, NULL, 5, NULL);
+    /* Initialize OV2640 camera before starting micro-ROS task */
+    ESP_ERROR_CHECK(ov2640_init());
+
+    /* DESIGN: 24KB stack for micro-ROS task; increased from 16KB to
+       accommodate camera publisher and JPEG buffer operations. */
+    xTaskCreate(micro_ros_task, "uros", 24576, NULL, 5, NULL);
 }


### PR DESCRIPTION
## Summary

Implements the OV2640 camera driver as an ESP-IDF component for the XIAO ESP32S3 Sense expansion board, with micro-ROS `CompressedImage` publisher integration.

- **New component** `firmware/components/ov2640/` — wraps `esp32-camera` with XIAO-specific pin mapping, Kconfig for resolution/quality/buffers, and a clean `init`/`capture`/`release` API
- **Main integration** — adds `camera/compressed` publisher (best-effort QoS) with a 100ms timer callback that captures JPEG frames and publishes `sensor_msgs/CompressedImage` at 10 Hz
- **Memory** — frame buffers and JPEG message buffer allocated in PSRAM; task stack increased to 24KB
- **Build fix** — adds `--allow-multiple-definition` linker flag to resolve micro-ROS vs newlib `__atomic_*_8` symbol conflict on IDF v5.3

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| QVGA default resolution | Camera is supplementary (not primary SLAM sensor per CLAUDE.md); smaller frames fit micro-ROS UDP transport better |
| 64KB JPEG buffer in PSRAM | Covers typical QVGA/CIF output while preserving internal SRAM |
| `GRAB_LATEST` mode | Ensures publisher always gets the freshest frame, dropping stale ones |
| `esp32-camera` via IDF component manager | Avoids adding another git submodule; standard ESP-IDF v5 dependency management |
| One-frame-at-a-time API | Simplest safe contract; matches our single-publisher 10Hz use case |

## Files Changed

| File | Change |
|------|--------|
| `firmware/components/ov2640/include/ov2640.h` | Public API: `ov2640_init`, `ov2640_capture`, `ov2640_release` |
| `firmware/components/ov2640/ov2640.c` | Driver implementation with XIAO pin mapping |
| `firmware/components/ov2640/Kconfig` | Resolution, JPEG quality, buffer count options |
| `firmware/components/ov2640/CMakeLists.txt` | Component build config |
| `firmware/components/ov2640/idf_component.yml` | esp32-camera managed dependency |
| `firmware/main/main.c` | Camera publisher, timer callback, message pre-allocation |
| `firmware/main/CMakeLists.txt` | Added ov2640 and esp_timer dependencies |
| `firmware/CMakeLists.txt` | Linker fix for micro-ROS atomic symbol conflict |

## Test Plan

- [x] CI firmware build passes (ESP-IDF v5.3 compilation)
- [ ] Verify Kconfig menu appears in `idf.py menuconfig` under "OV2640 Camera Driver"
- [ ] On-hardware: camera publishes JPEG frames on `/drone_N/camera/compressed` at ~10 Hz
- [ ] On-hardware: verify frame sizes are reasonable for QVGA (8–30 KB typical)

Closes #3