### PR TITLE
feat(firmware): wire main.c — FreeRTOS tasks + micro-ROS ToF/camera publishers

### DIFF
--- a/firmware/components/mavlink_bridge/mavlink_bridge.c
+++ b/firmware/components/mavlink_bridge/mavlink_bridge.c
@@ -160,7 +160,6 @@ esp_err_t mavlink_bridge_init(void)
 
 esp_err_t mavlink_bridge_create(rcl_node_t *node, rclc_executor_t *executor)
 {
-    rcl_allocator_t alloc = rcl_get_default_allocator();
     const rosidl_message_type_support_t *type =
         ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, UInt8MultiArray);
 

--- a/firmware/main/main.c
+++ b/firmware/main/main.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -18,6 +19,8 @@
 #include <rmw_microxrcedds_c/config.h>
 #include <rosidl_runtime_c/string_functions.h>
 #include <sensor_msgs/msg/compressed_image.h>
+#include <sensor_msgs/msg/point_cloud2.h>
+#include <sensor_msgs/msg/point_field.h>
 #include <uros_network_interfaces.h>
 
 #include "mavlink_bridge.h"
@@ -46,13 +49,179 @@ static const char *TAG = "drone_onboard";
         }                                                                      \
     } while (0)
 
+/* ── Constants ──────────────────────────────────────────────────────── */
+
+#define TOF_TIMER_MS       66   /* ~15 Hz */
+#define CAMERA_TIMER_MS    100  /* ~10 Hz */
+
+/* Executor handles: 2 timers (ToF + camera) + MAVLink subscriber */
+#define EXECUTOR_HANDLES   (2 + MAVLINK_BRIDGE_NUM_HANDLES)
+
+/* PointCloud2 layout: sensors * 64 zones, each point = (x,y,z) float32 */
+#define TOF_GRID_SIZE      8
+#define TOF_FOV_DEG        45.0f
+#define TOF_POINT_COUNT    (CONFIG_TOF_SENSOR_COUNT * TOF_ZONES)
+#define TOF_POINT_STEP     12  /* 3 * sizeof(float) */
+
 /* DESIGN: 64KB JPEG buffer covers QVGA/CIF typical output.
    Allocated in PSRAM to preserve internal SRAM for stack/heap. */
 #define CAMERA_JPEG_BUF_SIZE (64 * 1024)
 
+/* VL53L8CX angular resolution */
+#define TOF_PIXEL_ANG      ((TOF_FOV_DEG * (float)M_PI / 180.0f) / TOF_GRID_SIZE)
+
+/* ── Static message storage ────────────────────────────────────────── */
+
+static rcl_publisher_t tof_pub;
 static rcl_publisher_t camera_pub;
+
+static sensor_msgs__msg__PointCloud2 tof_msg;
 static sensor_msgs__msg__CompressedImage camera_msg;
 
+/* PointCloud2 backing buffers */
+static uint8_t tof_data_buf[TOF_POINT_COUNT * TOF_POINT_STEP];
+static sensor_msgs__msg__PointField tof_fields[3];
+static char tof_frame_id[32];
+static char tof_field_names[3][2] = {"x", "y", "z"};
+
+/* DESIGN: Sensor yaw angles (radians) relative to the drone body frame.
+   Front = +X, Right = -Y, Back = -X, Left = +Y. See docs/hardware_wiring.md
+   "Sensor Placement" diagram. */
+static const float sensor_yaw_rad[TOF_MAX_SENSORS] = {
+    0.0f,                /*  Front (#0): +X              */
+    -(float)M_PI / 2.0f, /*  Right (#1): +X rotated -90  */
+    (float)M_PI,         /*  Back  (#2): +X rotated 180  */
+    (float)M_PI / 2.0f,  /*  Left  (#3): +X rotated +90  */
+};
+
+/* ── Helpers ────────────────────────────────────────────────────────── */
+
+static void stamp_now(builtin_interfaces__msg__Time *stamp)
+{
+    int64_t us = esp_timer_get_time();
+    stamp->sec = (int32_t)(us / 1000000);
+    stamp->nanosec = (uint32_t)((us % 1000000) * 1000);
+}
+
+/* ── Message initialisation ─────────────────────────────────────────── */
+
+static void init_tof_msg(void)
+{
+    memset(&tof_msg, 0, sizeof(tof_msg));
+
+    snprintf(tof_frame_id, sizeof(tof_frame_id), "drone_%d_tof",
+             CONFIG_DRONE_ID);
+    tof_msg.header.frame_id.data = tof_frame_id;
+    tof_msg.header.frame_id.size = strlen(tof_frame_id);
+    tof_msg.header.frame_id.capacity = sizeof(tof_frame_id);
+
+    tof_msg.height = 1;
+    tof_msg.width = TOF_POINT_COUNT;
+    tof_msg.is_bigendian = false;
+    tof_msg.point_step = TOF_POINT_STEP;
+    tof_msg.row_step = TOF_POINT_COUNT * TOF_POINT_STEP;
+    tof_msg.is_dense = false;
+
+    /* PointField descriptors: x, y, z (FLOAT32) */
+    for (int i = 0; i < 3; i++) {
+        tof_fields[i].name.data = tof_field_names[i];
+        tof_fields[i].name.size = 1;
+        tof_fields[i].name.capacity = 2;
+        tof_fields[i].offset = (uint32_t)(i * sizeof(float));
+        tof_fields[i].datatype = sensor_msgs__msg__PointField__FLOAT32;
+        tof_fields[i].count = 1;
+    }
+    tof_msg.fields.data = tof_fields;
+    tof_msg.fields.size = 3;
+    tof_msg.fields.capacity = 3;
+
+    tof_msg.data.data = tof_data_buf;
+    tof_msg.data.size = 0;
+    tof_msg.data.capacity = sizeof(tof_data_buf);
+}
+
+/* ── ToF → PointCloud2 conversion ───────────────────────────────────── */
+
+/* Write a float into the PointCloud2 data buffer at the given byte offset.
+   Uses memcpy to avoid strict-aliasing violations (uint8_t* → float*). */
+static void write_float(uint8_t *buf, size_t offset, float value)
+{
+    memcpy(&buf[offset], &value, sizeof(float));
+}
+
+/* DESIGN: Convert N × 8x8 depth grids into a single unstructured PointCloud2
+   in the drone body frame. Each pixel's angle is derived from its grid
+   position and the VL53L8CX 45-degree FoV. Points with ranges_mm == 0
+   are kept as (0,0,0) and is_dense is set to false so downstream filters
+   can discard them. */
+static void tof_to_pointcloud(const tof_scan_t scans[], int num_sensors)
+{
+    int idx = 0;
+
+    for (int s = 0; s < num_sensors; s++) {
+        float yaw = sensor_yaw_rad[s];
+        float cos_yaw = cosf(yaw);
+        float sin_yaw = sinf(yaw);
+
+        for (int row = 0; row < TOF_GRID_SIZE; row++) {
+            float vert_ang = ((float)row - 3.5f) * TOF_PIXEL_ANG;
+            for (int col = 0; col < TOF_GRID_SIZE; col++) {
+                float horiz_ang = ((float)col - 3.5f) * TOF_PIXEL_ANG;
+                uint16_t dist_mm =
+                    scans[s].ranges_mm[row * TOF_GRID_SIZE + col];
+                size_t off = (size_t)idx * TOF_POINT_STEP;
+
+                if (dist_mm == 0) {
+                    write_float(tof_data_buf, off + 0, 0.0f);
+                    write_float(tof_data_buf, off + 4, 0.0f);
+                    write_float(tof_data_buf, off + 8, 0.0f);
+                } else {
+                    float dist_m = (float)dist_mm / 1000.0f;
+
+                    /* Point in sensor frame (+X = straight ahead) */
+                    float sx = dist_m * cosf(vert_ang) * cosf(horiz_ang);
+                    float sy = dist_m * cosf(vert_ang) * sinf(horiz_ang);
+                    float sz = dist_m * sinf(vert_ang);
+
+                    /* Rotate to body frame by sensor yaw */
+                    write_float(tof_data_buf, off + 0,
+                                sx * cos_yaw - sy * sin_yaw);
+                    write_float(tof_data_buf, off + 4,
+                                sx * sin_yaw + sy * cos_yaw);
+                    write_float(tof_data_buf, off + 8, sz);
+                }
+                idx++;
+            }
+        }
+    }
+    tof_msg.data.size = (size_t)(idx * TOF_POINT_STEP);
+}
+
+/* ── Timer callbacks ────────────────────────────────────────────────── */
+
+// cppcheck-suppress constParameterCallback
+static void tof_timer_callback(rcl_timer_t *timer, int64_t last_call_time)
+{
+    (void)last_call_time;
+    if (timer == NULL) {
+        return;
+    }
+
+    tof_scan_t scans[TOF_MAX_SENSORS];
+    for (int i = 0; i < CONFIG_TOF_SENSOR_COUNT; i++) {
+        esp_err_t err = tof_sensor_get_scan((uint8_t)i, &scans[i]);
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "ToF sensor %d read failed: %s", i,
+                     esp_err_to_name(err));
+        }
+    }
+
+    stamp_now(&tof_msg.header.stamp);
+    tof_to_pointcloud(scans, CONFIG_TOF_SENSOR_COUNT);
+    RCSOFTCHECK(rcl_publish(&tof_pub, &tof_msg, NULL));
+}
+
+// cppcheck-suppress constParameterCallback
 static void camera_timer_cb(rcl_timer_t *timer, int64_t last_call_time)
 {
     (void)last_call_time;
@@ -83,8 +252,11 @@ static void camera_timer_cb(rcl_timer_t *timer, int64_t last_call_time)
     ov2640_release();
 }
 
+/* ── micro-ROS task ─────────────────────────────────────────────────── */
+
 static void micro_ros_task(void *arg)
 {
+    (void)arg;
     rcl_allocator_t allocator = rcl_get_default_allocator();
     rclc_support_t support;
     rcl_node_t node;
@@ -106,20 +278,29 @@ static void micro_ros_task(void *arg)
     /* Node name: drone_N_onboard, namespace: drone_N */
     char node_name[32];
     snprintf(node_name, sizeof(node_name), "drone_%d_onboard", CONFIG_DRONE_ID);
-
     char ns[32];
     snprintf(ns, sizeof(ns), "drone_%d", CONFIG_DRONE_ID);
 
     RCCHECK(rclc_node_init_default(&node, node_name, ns, &support));
     ESP_LOGI(TAG, "node '%s/%s' created", ns, node_name);
 
-    /* --- Camera publisher (best-effort QoS for sensor data) --- */
+    /* ── Init static ToF message buffers ── */
+    init_tof_msg();
+
+    /* ── Publishers (best-effort QoS for sensor streams) ── */
+    RCCHECK(rclc_publisher_init_best_effort(
+        &tof_pub, &node,
+        ROSIDL_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, PointCloud2),
+        "tof/pointcloud"));
+    ESP_LOGI(TAG, "publisher: %s/tof/pointcloud (best_effort)", ns);
+
     RCCHECK(rclc_publisher_init_best_effort(
         &camera_pub, &node,
         ROSIDL_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, CompressedImage),
         "camera/compressed"));
+    ESP_LOGI(TAG, "publisher: %s/camera/compressed (best_effort)", ns);
 
-    /* Pre-allocate CompressedImage message fields */
+    /* Pre-allocate CompressedImage message fields in PSRAM */
     char frame_id[32];
     snprintf(frame_id, sizeof(frame_id), "drone_%d_camera", CONFIG_DRONE_ID);
     rosidl_runtime_c__String__assign(&camera_msg.header.frame_id, frame_id);
@@ -134,29 +315,38 @@ static void micro_ros_task(void *arg)
     camera_msg.data.capacity = CAMERA_JPEG_BUF_SIZE;
     camera_msg.data.size = 0;
 
-    /* --- Camera timer (10 Hz = 100 ms per CLAUDE.md spec) --- */
+    /* ── Timers: 66 ms (~15 Hz) ToF, 100 ms (~10 Hz) camera ── */
+    rcl_timer_t tof_timer;
+    RCCHECK(rclc_timer_init_default(&tof_timer, &support,
+                                    RCL_MS_TO_NS(TOF_TIMER_MS),
+                                    tof_timer_callback));
     rcl_timer_t camera_timer;
     RCCHECK(rclc_timer_init_default(&camera_timer, &support,
-                                    RCL_MS_TO_NS(100), camera_timer_cb));
+                                    RCL_MS_TO_NS(CAMERA_TIMER_MS),
+                                    camera_timer_cb));
 
-    /* Executor handles: camera timer (1) + MAVLink subscriber.
-       Will grow as ToF publisher is added. */
-    const unsigned int num_handles = 1 + MAVLINK_BRIDGE_NUM_HANDLES;
-    RCCHECK(
-        rclc_executor_init(&executor, &support.context, num_handles, &allocator));
+    /* ── Executor ── */
+    RCCHECK(rclc_executor_init(&executor, &support.context, EXECUTOR_HANDLES,
+                               &allocator));
+    RCCHECK(rclc_executor_add_timer(&executor, &tof_timer));
     RCCHECK(rclc_executor_add_timer(&executor, &camera_timer));
 
     /* MAVLink serial bridge (UART ↔ micro-ROS) */
     RCCHECK(mavlink_bridge_create(&node, &executor));
     RCCHECK(mavlink_bridge_start());
 
-    ESP_LOGI(TAG, "spinning...");
+    ESP_LOGI(TAG, "spinning (tof @%d ms, camera @%d ms, mavlink)...",
+             TOF_TIMER_MS, CAMERA_TIMER_MS);
+
     while (true) {
         RCSOFTCHECK(rclc_executor_spin_some(&executor, RCL_MS_TO_NS(100)));
         vTaskDelay(pdMS_TO_TICKS(10));
     }
 
+    /* Unreachable in normal operation; included for completeness */
     RCCHECK(rclc_executor_fini(&executor));
+    RCCHECK(rcl_publisher_fini(&tof_pub, &node));
+    RCCHECK(rcl_publisher_fini(&camera_pub, &node));
     RCCHECK(rcl_node_fini(&node));
     RCCHECK(rclc_support_fini(&support));
     vTaskDelete(NULL);
@@ -164,7 +354,7 @@ static void micro_ros_task(void *arg)
 
 void app_main(void)
 {
-    ESP_LOGI(TAG, "drone-swarm firmware v0.1.0 (drone_id=%d)", CONFIG_DRONE_ID);
+    ESP_LOGI(TAG, "drone-swarm firmware v0.3.0 (drone_id=%d)", CONFIG_DRONE_ID);
 
     /* NVS required by WiFi driver */
     esp_err_t ret = nvs_flash_init();
@@ -176,8 +366,7 @@ void app_main(void)
     ESP_ERROR_CHECK(ret);
 
     /* DESIGN: WiFi STA handled by micro-ROS component via its Kconfig
-       (SSID/password set in menuconfig, not hardcoded). Will be replaced
-       by custom WiFi mesh component when multi-drone networking is added. */
+       (SSID/password set in menuconfig, not hardcoded). */
     ESP_ERROR_CHECK(uros_network_interface_initialize());
 
     /* MAVLink UART must be ready before the micro-ROS task creates the
@@ -191,7 +380,8 @@ void app_main(void)
     ESP_ERROR_CHECK(tof_sensor_init());
     ESP_ERROR_CHECK(tof_sensor_start());
 
-    /* DESIGN: 24KB stack for micro-ROS task; increased from 16KB to
-       accommodate camera publisher and JPEG buffer operations. */
+    /* DESIGN: 24KB stack for micro-ROS task. Increased from 16KB (scaffold)
+       to accommodate ToF/camera publishers, timer callbacks, MAVLink bridge,
+       and the tof_to_pointcloud conversion. */
     xTaskCreate(micro_ros_task, "uros", 24576, NULL, 5, NULL);
 }


### PR DESCRIPTION
## Summary
- Add ToF PointCloud2 publisher to main.c micro-ROS pipeline
- 15 Hz timer reads cached scans via `tof_sensor_get_scan()` (from #28)
- `tof_to_pointcloud()` converts 4×8×8 depth grids to body-frame XYZ points
- Static PointCloud2 message with pre-allocated backing buffers (no malloc)
- Executor handles: ToF timer + camera timer + MAVLink subscriber (3 total)
- cppcheck inline suppressions for rclc timer callback signatures
- Removes unused `rcl_allocator_t` variable in mavlink_bridge.c

## Dependencies
- #22 (firmware scaffold) — merged
- #25 (MAVLink bridge) — merged
- #26 (OV2640 camera) — merged
- #28 (VL53L8CX ToF driver) — merged

## Test plan
- [ ] ESP-IDF Build (CI)
- [ ] cppcheck (CI)
- [ ] clang-tidy — pre-existing ground station failure, not related to this PR

Closes #5