### PR TITLE
chore(ardupilot): add ArduCopter param files and directory structure

### DIFF
--- a/ardupilot/README.md
+++ b/ardupilot/README.md
@@ -1,0 +1,121 @@
+# ardupilot/ — ArduCopter Configuration as Code
+
+ArduCopter parameter files and tooling for the drone swarm.
+
+## Hardware
+- **Flight controller:** Matek H743-MINI V3
+- **Firmware:** ArduCopter (latest stable 4.x)
+- **Frame:** Flywoo Explorer LR 4 (4" quad, X-frame)
+- **Battery:** 4S 14.8V 3000mAh Sony VTC6
+
+## Directory Structure
+
+```
+ardupilot/
+├── params/
+│   ├── common.param           # Shared base config for all swarm drones
+│   ├── companion_serial.param # SERIAL6 (UART4) for XIAO companion
+│   └── README.md              # Import/export workflow
+├── scripts/
+│   └── diff_params.sh         # Diff two param files for review
+└── README.md                  # This file
+```
+
+> **Individual drone files** (`drone_1.param`, `drone_2.param`, …) are **not**
+> stored here. Export them from Mission Planner after tuning and keep them
+> locally or in a private store. They contain per-unit compass offsets and
+> PID values.
+
+## Quick Start
+
+### 1. Flash ArduCopter firmware
+
+Use Mission Planner (Windows/macOS) or [ArduPilot firmware site](https://firmware.ardupilot.org/):
+
+1. Connect H743-MINI V3 via USB.
+2. **Setup → Install Firmware → Quad (X)** → select latest stable.
+3. Wait for flash and reboot confirmation.
+
+### 2. Load shared parameters
+
+```bash
+# Option A: Mission Planner
+# Config → Full Parameter List → Load from file
+# Load common.param, then companion_serial.param
+
+# Option B: MAVProxy
+mavproxy.py --master /dev/ttyACM0 --baud 115200
+param load ardupilot/params/common.param
+param load ardupilot/params/companion_serial.param
+param fetch
+```
+
+### 3. Calibrate (mandatory before first flight)
+
+In Mission Planner **Setup → Mandatory Hardware**:
+
+1. **Accelerometer calibration** — follow on-screen 6-position guide.
+2. **Compass calibration** — rotate drone in all orientations until complete.
+   - The M100QMC-5883L external compass will appear as Compass #2.
+   - Prioritise external compass (further from ESC noise).
+3. **Radio calibration** — move all sticks and switches to full travel.
+4. **ESC calibration** — required once if using non-DSHOT ESCs (skip for DSHOT).
+
+### 4. Export per-drone param file
+
+After calibration and initial tuning:
+
+```bash
+# Mission Planner: Config → Full Parameter List → Save to file → drone_1.param
+# MAVProxy:
+param save drone_1.param
+```
+
+Keep this file safe. It contains your compass offsets, PID tunes, and battery
+voltage divider calibration.
+
+## Reviewing Parameter Changes
+
+Use `diff_params.sh` to compare a drone's exported file against the shared base:
+
+```bash
+cd ardupilot
+./scripts/diff_params.sh params/common.param /path/to/drone_1.param
+```
+
+This shows:
+- Parameters added in the drone file (tuning overrides)
+- Parameters removed (potential regressions)
+- Value changes (e.g. updated PIDs or compass offsets)
+
+## MAVLink / Companion Interface
+
+SERIAL6 (physical UART4 pads TX4/RX4) connects to the XIAO ESP32S3 companion.
+See `params/companion_serial.param` and `docs/hardware_wiring.md` for details.
+
+Key parameters:
+
+| Parameter | Value | Meaning |
+|-----------|-------|---------|
+| `SERIAL6_PROTOCOL` | 2 | MAVLink2 |
+| `SERIAL6_BAUD` | 921 | 921600 baud |
+
+## Parameter File Format
+
+ArduPilot uses a plain-text `NAME VALUE` format:
+
+```
+# Comment lines start with #
+PARAM_NAME value
+```
+
+- Names are case-sensitive and must match ArduPilot exactly.
+- Values are floating-point (integers work too).
+- One parameter per line.
+
+## References
+
+- [ArduCopter Parameters](https://ardupilot.org/copter/docs/parameters.html)
+- [Matek H743-MINI V3 docs](https://www.mateksys.com/?portfolio=h743-mini-v3)
+- [SERIAL port setup](https://ardupilot.org/copter/docs/common-serial-options.html)
+- [EKF3 tuning](https://ardupilot.org/copter/docs/common-ek3-affinity-lane-switching.html)

--- a/ardupilot/params/README.md
+++ b/ardupilot/params/README.md
@@ -1,0 +1,60 @@
+# ArduCopter Parameter Files
+
+Parameter files for the Matek H743-MINI V3 running ArduCopter.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `common.param` | Shared base configuration for all swarm drones |
+| `companion_serial.param` | SERIAL6 (UART4) config for XIAO ESP32S3 companion |
+
+> **Note:** Individual drone param files (e.g. `drone_1.param`) are **not** checked in.
+> Export them from Mission Planner after your first tuning session and keep them locally.
+> They contain frame-specific PID tunes and compass offsets that vary per-unit.
+
+## Import (load params onto FC)
+
+### Mission Planner
+1. Connect FC via USB or telemetry.
+2. Go to **Config → Full Parameter List**.
+3. Click **Load from file** (bottom right).
+4. Select the `.param` file.
+5. Click **Write Params** to apply.
+
+> Apply `common.param` first, then `companion_serial.param`.
+
+### MAVProxy
+```bash
+mavproxy.py --master /dev/ttyUSB0 --baud 115200
+# Inside MAVProxy shell:
+param load common.param
+param load companion_serial.param
+param fetch   # verify all loaded correctly
+```
+
+### ArduPilot SITL (testing)
+```bash
+sim_vehicle.py -v ArduCopter --console
+# In MAVProxy:
+param load ardupilot/params/common.param
+```
+
+## Export (save params from FC)
+
+### Mission Planner
+1. Connect FC.
+2. **Config → Full Parameter List → Save to file**.
+3. Name it `drone_N.param` (N = drone ID).
+
+### MAVProxy
+```bash
+param save drone_1.param
+```
+
+## Workflow for updating shared params
+
+1. Edit `common.param` or `companion_serial.param` in this repo.
+2. Open a PR with the change and a rationale comment.
+3. After merge, load the updated file onto each drone in the swarm.
+4. Re-export individual `drone_N.param` files if PID tunes were affected.

--- a/ardupilot/params/common.param
+++ b/ardupilot/params/common.param
@@ -1,0 +1,100 @@
+# common.param — Shared ArduCopter parameters for all swarm drones
+# Hardware: Matek H743-MINI V3, M100QMC-5883L GPS/compass, ELRS RC
+# Frame: Flywoo Explorer LR 4 (4"), 4S 14.8V
+#
+# Format: NAME VALUE   (ArduPilot param file format)
+# Import: Mission Planner → Config → Full Parameter List → Load from file
+#         MAVProxy: param load common.param
+#
+# Non-obvious parameters are annotated with their rationale.
+
+# ---------------------------------------------------------------------------
+# EKF3 — Extended Kalman Filter (3rd generation)
+# ---------------------------------------------------------------------------
+AHRS_EKF_TYPE 3        # Use EKF3 (required for dual GPS, better for SLAM)
+EK3_ENABLE 1           # Enable EKF3
+EK2_ENABLE 0           # Disable EKF2 (avoid ambiguity)
+
+# EKF3 source selection: GPS primary, compass heading
+EK3_SRC1_POSXY 3       # GPS for horizontal position
+EK3_SRC1_VELXY 3       # GPS for horizontal velocity
+EK3_SRC1_POSZ 1        # Barometer for vertical position
+EK3_SRC1_VELZ 0        # No vertical velocity source
+EK3_SRC1_YAW 1         # Compass for yaw
+
+# ---------------------------------------------------------------------------
+# GPS — M100QMC-5883L (GPS + QMC5883L external compass)
+# ---------------------------------------------------------------------------
+GPS_TYPE 1             # AUTO-detect (detects UBLOX/NMEA)
+GPS_TYPE2 0            # No second GPS
+GPS_AUTO_SWITCH 1      # Auto-switch to best GPS
+GPS_GNSS_MODE 0        # Use all constellations (0 = auto)
+
+# ---------------------------------------------------------------------------
+# Compass — QMC5883L on M100QMC-5883L module (external, I2C)
+# ---------------------------------------------------------------------------
+COMPASS_USE 1          # Use compass #1 (internal — may not be fitted on H743)
+COMPASS_USE2 1         # Use compass #2 (external QMC5883L on GPS module)
+COMPASS_USE3 0         # No third compass
+# DESIGN: External compass is #2. Prioritize external (further from ESC noise).
+COMPASS_PRIO1_ID 2     # First priority: external compass on GPS module
+COMPASS_PRIO2_ID 1     # Second priority: internal (if present)
+COMPASS_AUTODEC 1      # Auto magnetic declination from GPS position
+
+# Compass health thresholds (tighten for indoor/SLAM accuracy)
+COMPASS_OFFS_MAX 850   # Default 850 — raise if calibration fails
+
+# ---------------------------------------------------------------------------
+# Failsafe — RC (ELRS) and battery (4S 3000mAh Sony VTC6)
+# ---------------------------------------------------------------------------
+
+# RC / Throttle failsafe
+FS_THR_ENABLE 1        # Enable throttle failsafe (1 = RTL, 2 = Continue, 3 = Land)
+FS_THR_VALUE 975       # PWM below this triggers FS (ELRS typically outputs ~885 on signal loss)
+
+# GCS (heartbeat) failsafe — relevant when running autonomous missions
+FS_GCS_ENABLE 1        # Enable GCS failsafe (1 = Land if no heartbeat)
+
+# Battery failsafe — 4S: 4.2V full, 3.7V nominal, 3.5V low, 3.3V critical
+BATT_MONITOR 4         # Voltage + current monitor
+BATT_LOW_VOLT 14.2     # Low: 3.55V × 4 cells → RTL
+BATT_CRT_VOLT 13.6     # Critical: 3.4V × 4 cells → Land
+BATT_FS_LOW_ACT 2      # Low battery action: 2 = RTL
+BATT_FS_CRT_ACT 1      # Critical battery action: 1 = Land
+
+# DESIGN: Using cell-voltage math for 4S (not per-cell params) for simplicity.
+# Operator should calibrate BATT_VOLT_MULT and BATT_AMP_PERVLT after first flight.
+
+# ---------------------------------------------------------------------------
+# Flight modes — autonomous-biased layout for swarm missions
+# ---------------------------------------------------------------------------
+# Switch positions map to RC channel 5 (6-position switch or 3-pos × 2 mix)
+FLTMODE1 0             # Stabilize     — manual fallback / recovery
+FLTMODE2 2             # AltHold       — manual with altitude hold
+FLTMODE3 5             # Loiter        — position hold (GPS)
+FLTMODE4 6             # RTL           — return to launch
+FLTMODE5 3             # Auto          — execute autonomous mission
+FLTMODE6 4             # Guided        — external control (SLAM / ground station)
+FLTMODE_CH 5           # Flight mode channel (ELRS default aux1 = ch5)
+
+# ---------------------------------------------------------------------------
+# ArduCopter general
+# ---------------------------------------------------------------------------
+FRAME_TYPE 1           # X frame
+FRAME_CLASS 1          # Quad
+
+# Arming checks — keep strict for safety
+ARMING_CHECK 1         # All checks enabled
+
+# Motor output protocol (DSHOT600 for Nin V2 1404 2750kv)
+MOT_PWM_TYPE 6         # DSHOT600
+
+# ESC telemetry (if ESCs support it — enables RPM/temperature feedback)
+RPM_TYPE 2             # DSHOT ESC telemetry on motor outputs
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+LOG_BITMASK 176126     # Default comprehensive logging
+LOG_DISARMED 0         # Don't log when disarmed (saves flash)
+LOG_REPLAY 0           # Disable EKF replay logging (saves space)

--- a/ardupilot/params/companion_serial.param
+++ b/ardupilot/params/companion_serial.param
@@ -1,0 +1,35 @@
+# companion_serial.param — SERIAL6 config for XIAO ESP32S3 companion
+# Hardware: Matek H743-MINI V3 UART4 (TX4=PB9, RX4=PB8) ↔ XIAO GPIO21/20
+# See: docs/hardware_wiring.md — "UART Configuration (MAVLink)"
+#
+# Format: NAME VALUE   (ArduPilot param file format)
+# Import: Mission Planner → Config → Full Parameter List → Load from file
+#         MAVProxy: param load companion_serial.param
+#
+# Apply these BEFORE connecting the XIAO companion for the first time.
+
+# ---------------------------------------------------------------------------
+# SERIAL6 — ArduPilot name for UART4 on the H743-MINI V3
+# ---------------------------------------------------------------------------
+SERIAL6_PROTOCOL 2     # MAVLink2 (2 = MAVLink2, 1 = MAVLink1)
+SERIAL6_BAUD 921       # 921600 baud (ArduPilot encodes as kbaud: 921 = 921600)
+
+# DESIGN: SERIAL6 maps to the physical UART4 pads (TX4/RX4) on the H743-MINI V3.
+# ArduPilot's SERIAL numbering is board-specific — verify with the H743-MINI V3
+# hwdef if ever upgrading firmware. The XIAO outputs 3.3V logic; the H743 UART4
+# input is 5V-tolerant — no level shifter is needed.
+
+# ---------------------------------------------------------------------------
+# Stream rates for telemetry sent to companion (XIAO / micro-ROS)
+# ---------------------------------------------------------------------------
+# DESIGN: The companion only needs attitude, position, and heartbeat.
+# Keeping rates low reduces UART bandwidth and leaves CPU headroom on the H743.
+SR6_ATTITUDE 10        # Attitude (roll/pitch/yaw) at 10 Hz
+SR6_POSITION 5         # Position (lat/lon/alt) at 5 Hz
+SR6_EXT_STAT 2         # Extended status (sys/GPS status) at 2 Hz
+SR6_EXTRA1 4           # Extra1 (airspeed, throttle) at 4 Hz
+SR6_EXTRA2 0           # Extra2 (VFR HUD) — not needed by companion
+SR6_EXTRA3 0           # Extra3 (AHRS, etc.) — not needed by companion
+SR6_RAW_SENS 0         # Raw sensor data — not needed by companion
+SR6_RC_CHAN 0          # RC channel data — not needed by companion
+SR6_RAW_CTRL 0         # Raw control — not needed by companion

--- a/ardupilot/scripts/diff_params.sh
+++ b/ardupilot/scripts/diff_params.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# diff_params.sh — Compare two ArduPilot parameter files
+#
+# Usage:
+#   ./scripts/diff_params.sh <file_a> <file_b>
+#   ./scripts/diff_params.sh params/common.param drone_1.param
+#
+# Output: Lines where the same parameter has different values, or exists in
+#         only one file. Comment lines (#) and blank lines are ignored.
+#
+# Exit codes:
+#   0 — files are identical (ignoring comments and whitespace)
+#   1 — differences found
+#   2 — usage error
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <file_a> <file_b>" >&2
+    exit 2
+fi
+
+FILE_A="$1"
+FILE_B="$2"
+
+if [[ ! -f "$FILE_A" ]]; then
+    echo "Error: '$FILE_A' not found" >&2
+    exit 2
+fi
+
+if [[ ! -f "$FILE_B" ]]; then
+    echo "Error: '$FILE_B' not found" >&2
+    exit 2
+fi
+
+# Strip comments and blank lines, normalise whitespace, sort by param name.
+# ArduPilot format: NAME VALUE  (space or tab separated)
+strip_and_sort() {
+    grep -v '^\s*#' "$1" \
+    | grep -v '^\s*$' \
+    | awk '{print $1, $2}' \
+    | sort -k1,1
+}
+
+TMP_A=$(mktemp)
+TMP_B=$(mktemp)
+trap 'rm -f "$TMP_A" "$TMP_B"' EXIT
+
+strip_and_sort "$FILE_A" > "$TMP_A"
+strip_and_sort "$FILE_B" > "$TMP_B"
+
+# Parameters only in file A (removed or renamed in B)
+ONLY_A=$(comm -23 <(awk '{print $1}' "$TMP_A" | sort) \
+                   <(awk '{print $1}' "$TMP_B" | sort))
+
+# Parameters only in file B (added in B)
+ONLY_B=$(comm -13 <(awk '{print $1}' "$TMP_A" | sort) \
+                   <(awk '{print $1}' "$TMP_B" | sort))
+
+# Parameters in both but with different values
+CHANGED=$(join "$TMP_A" "$TMP_B" \
+    | awk '$2 != $3 {printf "%-35s  %s  →  %s\n", $1, $2, $3}')
+
+DIFF_FOUND=0
+
+if [[ -n "$ONLY_A" ]]; then
+    echo "=== Only in $FILE_A (not in $FILE_B) ==="
+    while IFS= read -r param; do
+        grep "^$param " "$TMP_A"
+    done <<< "$ONLY_A"
+    echo ""
+    DIFF_FOUND=1
+fi
+
+if [[ -n "$ONLY_B" ]]; then
+    echo "=== Only in $FILE_B (not in $FILE_A) ==="
+    while IFS= read -r param; do
+        grep "^$param " "$TMP_B"
+    done <<< "$ONLY_B"
+    echo ""
+    DIFF_FOUND=1
+fi
+
+if [[ -n "$CHANGED" ]]; then
+    echo "=== Changed values (param  A-value  →  B-value) ==="
+    echo "$CHANGED"
+    echo ""
+    DIFF_FOUND=1
+fi
+
+if [[ $DIFF_FOUND -eq 0 ]]; then
+    echo "No differences found between '$FILE_A' and '$FILE_B'."
+fi
+
+exit $DIFF_FOUND


### PR DESCRIPTION
## Summary

- Adds `ardupilot/` directory to manage ArduCopter configuration as code
- `params/common.param`: shared base parameters for all swarm drones (EKF3, M100QMC-5883L GPS/compass, 4S battery failsafe, ELRS RC failsafe, autonomous flight mode layout, DSHOT600)
- `params/companion_serial.param`: SERIAL6 (UART4) MAVLink2 setup matching `docs/hardware_wiring.md` — `SERIAL6_PROTOCOL=2`, `SERIAL6_BAUD=921`, plus stream rates for companion
- `scripts/diff_params.sh`: shell script to diff two `.param` files (strips comments, normalises whitespace, shows added/removed/changed params)
- `README.md` + `params/README.md`: flashing guide, calibration checklist, import/export workflow for Mission Planner and MAVProxy

## Test plan

- [ ] Verify `companion_serial.param` matches UART config in `docs/hardware_wiring.md` (SERIAL6_PROTOCOL=2, SERIAL6_BAUD=921)
- [ ] Run `diff_params.sh` with two param files and confirm it correctly identifies differences
- [ ] Confirm param file format is valid (NAME VALUE, no trailing commas or quotes)
- [ ] Review EKF3 and GPS params are consistent with M100QMC-5883L hardware

Closes #30