### PR TITLE
feat(docker): runtime docker-compose for ground station on macOS

### DIFF
--- a/docker/Dockerfile.ground-runtime
+++ b/docker/Dockerfile.ground-runtime
@@ -1,0 +1,36 @@
+# Ground station runtime image — ROS 2 Humble (arm64 for Apple Silicon)
+# Builds the ROS workspace from volume-mounted source at container start,
+# enabling edit-on-Mac / run-in-container development.
+#
+# Usage (via docker-compose.runtime.yml):
+#   docker compose -f docker/docker-compose.runtime.yml build
+#   docker compose -f docker/docker-compose.runtime.yml up
+
+FROM ros:humble-ros-base
+
+# Install build tools, foxglove bridge for web visualization, and rosdep
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        python3-colcon-common-extensions \
+        python3-rosdep \
+        ros-humble-foxglove-bridge \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rosdep update --rosdistro=humble || true
+
+# DESIGN: Workspace root is /ws. Source arrives via volume mount at /ws/src.
+# Build artifacts live in named volumes (/ws/build, /ws/install) so they
+# persist across container restarts and incremental rebuilds are fast.
+WORKDIR /ws
+
+# DESIGN: colcon runs at container start (not image build) so that changes
+# made on the Mac host are picked up without rebuilding the image.
+# --symlink-install makes Python files effective immediately without rebuild.
+CMD ["bash", "-c", "\
+    source /opt/ros/humble/setup.bash && \
+    rosdep install --from-paths src --ignore-src -y || true && \
+    colcon build --symlink-install && \
+    source install/setup.bash && \
+    exec ros2 launch ground_station ground_station.launch.py \
+"]

--- a/docker/docker-compose.runtime.yml
+++ b/docker/docker-compose.runtime.yml
@@ -1,0 +1,50 @@
+# Runtime Docker Compose — ground station on macOS (Apple Silicon)
+#
+# Usage:
+#   docker compose -f docker/docker-compose.runtime.yml build
+#   docker compose -f docker/docker-compose.runtime.yml up
+#   docker compose -f docker/docker-compose.runtime.yml up ground-station
+
+services:
+  # micro-ROS agent: UDP ↔ ROS 2 bridge for drone topics over WiFi mesh.
+  # DESIGN: macOS Docker Desktop does not support network_mode: host.
+  # Port 8888/udp is forwarded so drone firmware can reach the agent at
+  # <mac-ip>:8888 on the local WiFi network. Configure drone firmware with
+  # MICRO_ROS_AGENT_IP = <mac-ip> and MICRO_ROS_AGENT_PORT = 8888.
+  micro-ros-agent:
+    image: microros/micro-ros-agent:humble
+    platform: linux/arm64
+    command: udp4 --port 8888
+    ports:
+      - "8888:8888/udp"
+    restart: unless-stopped
+
+  # Ground station: all ROS 2 nodes in one container.
+  # DESIGN: Foxglove bridge runs inside this container so all nodes share
+  # one ROS domain without cross-container DDS multicast issues on macOS.
+  # Open Foxglove Studio and connect to ws://localhost:8765 to visualize.
+  ground-station:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.ground-runtime
+    platform: linux/arm64
+    volumes:
+      # Source mounts — edit on Mac, changes picked up on next colcon build.
+      - ../ground_station:/ws/src/ground_station:ro
+      - ../msgs:/ws/src/msgs:ro
+      # Persistent build artifacts so incremental rebuilds after restart are fast.
+      - ground-station-build:/ws/build
+      - ground-station-install:/ws/install
+      - ground-station-log:/ws/log
+    environment:
+      - ROS_DOMAIN_ID=0
+    ports:
+      - "8765:8765"  # Foxglove WebSocket — connect Foxglove Studio to ws://localhost:8765
+    depends_on:
+      - micro-ros-agent
+    restart: unless-stopped
+
+volumes:
+  ground-station-build:
+  ground-station-install:
+  ground-station-log:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,151 @@
+# Getting Started — macOS Ground Station
+
+This guide covers running the drone-swarm-slam ground station on macOS (Apple
+Silicon) using Docker.
+
+## Prerequisites
+
+- Docker Desktop for Mac (arm64) — <https://docs.docker.com/desktop/install/mac-install/>
+- Foxglove Studio (optional, for visualization) — <https://foxglove.dev/studio>
+
+## Quick Start
+
+### 1. Build the runtime image
+
+```bash
+docker compose -f docker/docker-compose.runtime.yml build
+```
+
+This downloads the ROS 2 Humble base image and installs dependencies
+(~2 GB on first run, cached after that).
+
+### 2. Launch the full stack
+
+```bash
+docker compose -f docker/docker-compose.runtime.yml up
+```
+
+This starts:
+
+| Service | What it does |
+|---------|-------------|
+| `micro-ros-agent` | UDP bridge — receives topics from drones over WiFi |
+| `ground-station` | All ROS 2 nodes + Foxglove bridge |
+
+The first start builds the ROS workspace from source (~1–3 min). Subsequent
+starts reuse cached build artifacts and are much faster.
+
+### 3. Visualize
+
+Open [Foxglove Studio](https://foxglove.dev/studio) and connect to:
+
+```
+ws://localhost:8765
+```
+
+Useful topics to add panels for:
+
+| Topic | Type | Panel |
+|-------|------|-------|
+| `/slam/map` | `nav_msgs/OccupancyGrid` | Map |
+| `/slam/map_3d` | `sensor_msgs/PointCloud2` | 3D |
+| `/drone_1/pose/estimated` | `geometry_msgs/PoseStamped` | Pose |
+
+### 4. Launch ground station only (no micro-ROS agent)
+
+Useful when testing with the ToF simulator instead of real hardware:
+
+```bash
+docker compose -f docker/docker-compose.runtime.yml up ground-station
+```
+
+## Network Setup
+
+### WiFi mesh and drone IP scheme
+
+```
+MacBook Pro (ground station)
+  ├── Docker: micro-ros-agent listening on UDP 8888
+  └── WiFi 5 network (same SSID as drones)
+
+Drone ESP32S3 (micro-ROS client)
+  └── WiFi → UDP → <mac-ip>:8888
+```
+
+To find your Mac's WiFi IP:
+
+```bash
+ipconfig getifaddr en0
+```
+
+Configure each drone with that IP as the micro-ROS agent address
+(see `firmware/main/Kconfig` → `MICRO_ROS_AGENT_IP`).
+
+### UDP ports
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 8888 | UDP | micro-ROS agent (drones → ground) |
+| 8765 | TCP | Foxglove WebSocket (browser → ground) |
+
+## Development Workflow (Edit on Mac, Run in Container)
+
+Source files are volume-mounted read-only into the container. After editing C++
+source on the Mac, rebuild inside the container:
+
+```bash
+docker compose -f docker/docker-compose.runtime.yml exec ground-station bash -c \
+    "source /opt/ros/humble/setup.bash && \
+     colcon build --symlink-install --packages-select <package_name> && \
+     source install/setup.bash"
+```
+
+Then restart the nodes:
+
+```bash
+docker compose -f docker/docker-compose.runtime.yml restart ground-station
+```
+
+> **Tip:** Python launch files and parameter files take effect immediately
+> without a colcon rebuild (symlink-install links directly to source).
+
+## Testing with the ToF Simulator
+
+Run a simulated drone without hardware to exercise the full pipeline:
+
+```bash
+# Terminal 1 — ground station (builds and launches all nodes)
+docker compose -f docker/docker-compose.runtime.yml up ground-station
+
+# Terminal 2 — ToF simulator (inside the same container)
+docker compose -f docker/docker-compose.runtime.yml exec ground-station bash -c \
+    "source /opt/ros/humble/setup.bash && \
+     source install/setup.bash && \
+     ros2 launch drone_swarm_tof_simulator tof_simulator.launch.py drone_id:=1"
+```
+
+The simulator publishes synthetic point clouds to `/drone_1/tof/pointcloud`,
+which the PointcloudAssembler and SLAM node consume.
+
+## CI vs Runtime Images
+
+| | `docker-compose.yml` | `docker-compose.runtime.yml` |
+|-|----------------------|------------------------------|
+| Purpose | CI build + test | Runtime on macOS |
+| Entrypoint | `colcon build && colcon test` | `colcon build && ros2 launch` |
+| Source mount | Read-only (verifies checkout) | Read-only (live dev) |
+| Persisted artifacts | No | Yes (named volumes) |
+| Foxglove bridge | No | Yes (port 8765) |
+| micro-ROS agent | No | Yes (port 8888/udp) |
+
+## Stopping
+
+```bash
+docker compose -f docker/docker-compose.runtime.yml down
+```
+
+To also remove build caches (forces a full rebuild next time):
+
+```bash
+docker compose -f docker/docker-compose.runtime.yml down -v
+```

--- a/ground_station/launch/ground_station.launch.py
+++ b/ground_station/launch/ground_station.launch.py
@@ -1,8 +1,17 @@
-"""Launch file for the drone-swarm-slam ground station."""
+"""Launch file for the drone-swarm-slam ground station.
+
+Starts all ground station nodes:
+  - PointcloudAssembler  (ToF scans → merged PointCloud2)
+  - SlamNode             (PointCloud2 → OccupancyGrid / 3D map)
+  - PoseEstimator        (map + drone pose → MAVLink corrections)
+  - MissionController    (waypoint sequencing)
+  - FoxgloveBridge       (web visualization on ws://localhost:8765)
+"""
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
 
 
 def generate_launch_description():
@@ -11,14 +20,91 @@ def generate_launch_description():
         default_value='1',
         description='Number of drones in the swarm'
     )
+    drone_id_arg = DeclareLaunchArgument(
+        'drone_id',
+        default_value='1',
+        description='Drone identifier (used for single-drone per-node params)'
+    )
 
     num_drones = LaunchConfiguration('num_drones')
+    drone_id = LaunchConfiguration('drone_id')
 
-    # DESIGN: Nodes will be added here as they are implemented:
-    # - SLAM node (pointcloud -> map)
-    # - Pose estimator (corrections -> drone)
-    # - Mission controller (planning, multi-drone)
-
+    # DESIGN: For now, one pose_estimator and mission_controller instance covers
+    # drone 1. Multi-drone support will add instances here once orchestration
+    # (issue #11) stabilises.
     return LaunchDescription([
         num_drones_arg,
+        drone_id_arg,
+
+        Node(
+            package='drone_swarm_pointcloud_assembler',
+            executable='pointcloud_assembler_node',
+            name='pointcloud_assembler',
+            output='screen',
+            parameters=[{
+                'drone_ids': [1],
+                'window_duration_sec': 1.0,
+                'max_clouds': 100,
+                'publish_rate_hz': 10.0,
+                'output_frame': 'odom',
+            }],
+        ),
+
+        Node(
+            package='drone_swarm_slam',
+            executable='slam_node',
+            name='slam_node',
+            output='screen',
+            parameters=[{
+                'num_drones': num_drones,
+                'map_resolution': 0.1,
+                'map_size_x': 20.0,
+                'map_size_y': 20.0,
+                'map_height_min': -0.5,
+                'map_height_max': 3.0,
+                'publish_rate_hz': 1.0,
+                'map_frame': 'map',
+            }],
+        ),
+
+        Node(
+            package='drone_swarm_pose_estimator',
+            executable='pose_estimator_node',
+            name='pose_estimator',
+            output='screen',
+            parameters=[{
+                'drone_id': drone_id,
+                'sysid': 1,
+                'compid': 195,
+            }],
+        ),
+
+        Node(
+            package='drone_swarm_mission_controller',
+            executable='mission_controller_node',
+            name='mission_controller',
+            output='screen',
+            parameters=[{
+                'drone_id': drone_id,
+                'waypoint_radius_m': 0.5,
+                'republish_rate_hz': 1.0,
+                # DESIGN: Override waypoints at runtime via a YAML params file:
+                #   ros2 launch ground_station ground_station.launch.py \
+                #     --ros-args --params-file mission.yaml
+                'waypoints': [0.0, 0.0, 1.0],
+            }],
+        ),
+
+        # Foxglove bridge: web-based visualization on ws://localhost:8765.
+        # Connect with Foxglove Studio (https://foxglove.dev/studio).
+        Node(
+            package='foxglove_bridge',
+            executable='foxglove_bridge',
+            name='foxglove_bridge',
+            output='screen',
+            parameters=[{
+                'port': 8765,
+                'address': '0.0.0.0',
+            }],
+        ),
     ])


### PR DESCRIPTION
## Summary

- **`docker/Dockerfile.ground-runtime`**: ROS 2 Humble runtime image that builds the workspace from volume-mounted source at container start, enabling edit-on-Mac / run-in-container development
- **`docker/docker-compose.runtime.yml`**: Two-service stack — `micro-ros-agent` (UDP port 8888 for drone WiFi) and `ground-station` (all ROS 2 nodes + Foxglove bridge on port 8765)
- **`ground_station/launch/ground_station.launch.py`**: Updated to launch all nodes: PointcloudAssembler, SlamNode, PoseEstimator, MissionController, FoxgloveBridge
- **`docs/getting_started.md`**: macOS setup guide covering quick start, network config (WiFi mesh, UDP ports), development workflow, and ToF simulator testing

## Key design decisions

- **No `network_mode: host`** — macOS Docker Desktop doesn't support it; UDP port 8888 is forwarded explicitly for drone→agent traffic
- **All ROS 2 nodes in one container** — avoids cross-container DDS multicast issues on macOS; Foxglove bridge shares the same ROS domain
- **Named volumes for build artifacts** — incremental rebuilds are fast after the first start without losing state between restarts
- **Source mounted read-only** — prevents container writes to the Mac workspace while still enabling live editing

## Test plan

- [x] CI ground-build passes (`docker compose -f docker/docker-compose.yml run ground-build`)
- [ ] `docker compose -f docker/docker-compose.runtime.yml build` succeeds
- [ ] `docker compose -f docker/docker-compose.runtime.yml up` starts both services
- [ ] Foxglove Studio connects to `ws://localhost:8765`
- [ ] micro-ROS agent listens on UDP 8888

Closes #38