### PR TITLE
fix(ground): apply TF2 transforms in SLAM and pointcloud assembler

### DIFF
--- a/ground_station/launch/ground_station.launch.py
+++ b/ground_station/launch/ground_station.launch.py
@@ -1,7 +1,9 @@
 """Launch file for the drone-swarm-slam ground station.
 
 Starts all ground station nodes:
-  - PointcloudAssembler  (ToF scans → merged PointCloud2)
+  - TfBroadcaster        (base_link → tof_*/camera static transforms, from #53)
+  - PoseExtractor        (MAVLink EKF → map → base_link TF, from #52)
+  - PointcloudAssembler  (ToF scans → merged PointCloud2 in map frame)
   - SlamNode             (PointCloud2 → OccupancyGrid / 3D map)
   - PoseEstimator        (map + drone pose → MAVLink corrections)
   - MissionController    (waypoint sequencing)
@@ -36,6 +38,34 @@ def generate_launch_description():
         num_drones_arg,
         drone_id_arg,
 
+        # TF broadcaster: publishes static drone_1/base_link → drone_1/tof_*
+        # and drone_1/camera transforms. Must start before pose_extractor so
+        # the full TF tree (map → base_link → sensors) is available early.
+        # Provided by issue #53.
+        Node(
+            package='drone_swarm_tf_broadcaster',
+            executable='tf_broadcaster_node',
+            name='tf_broadcaster',
+            output='screen',
+            parameters=[{
+                'drone_id': drone_id,
+            }],
+        ),
+
+        # Pose extractor: subscribes to MAVLink EKF data and publishes
+        # map → drone_N/base_link TF. Requires tf_broadcaster to be running
+        # so the downstream TF tree is complete.
+        # Provided by issue #52.
+        Node(
+            package='drone_swarm_pose_extractor',
+            executable='pose_extractor_node',
+            name='pose_extractor',
+            output='screen',
+            parameters=[{
+                'drone_id': drone_id,
+            }],
+        ),
+
         Node(
             package='drone_swarm_pointcloud_assembler',
             executable='pointcloud_assembler_node',
@@ -46,7 +76,7 @@ def generate_launch_description():
                 'window_duration_sec': 1.0,
                 'max_clouds': 100,
                 'publish_rate_hz': 10.0,
-                'output_frame': 'odom',
+                'output_frame': 'map',
             }],
         ),
 

--- a/ground_station/src/pointcloud_assembler/CMakeLists.txt
+++ b/ground_station/src/pointcloud_assembler/CMakeLists.txt
@@ -9,9 +9,13 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_sensor_msgs REQUIRED)
 
 # Library: pure assembler logic (no ROS spin, testable standalone)
 add_library(pointcloud_assembler_lib
@@ -37,9 +41,13 @@ target_include_directories(pointcloud_assembler_node PUBLIC
 )
 target_link_libraries(pointcloud_assembler_node pointcloud_assembler_lib)
 ament_target_dependencies(pointcloud_assembler_node
+  geometry_msgs
   rclcpp
   sensor_msgs
   std_msgs
+  tf2
+  tf2_ros
+  tf2_sensor_msgs
 )
 
 install(TARGETS pointcloud_assembler_node

--- a/ground_station/src/pointcloud_assembler/include/pointcloud_assembler/pointcloud_assembler.hpp
+++ b/ground_station/src/pointcloud_assembler/include/pointcloud_assembler/pointcloud_assembler.hpp
@@ -21,10 +21,9 @@ struct AssemblerConfig {
 /// with no ROS dependencies except the message type.
 ///
 /// DESIGN: This is a simple time-windowed accumulator. It does not perform
-/// any coordinate-frame transforms — callers are responsible for ensuring
-/// all incoming clouds are expressed in the same frame before adding them,
-/// or accepting that the assembled cloud mixes frames (acceptable for the
-/// initial SLAM bootstrap stage before TF2 integration).
+/// coordinate-frame transforms — callers (i.e. PointcloudAssemblerNode) are
+/// responsible for transforming all clouds to a common frame via TF2 before
+/// calling add_cloud().
 class PointcloudAssembler {
  public:
   explicit PointcloudAssembler(const AssemblerConfig& config);

--- a/ground_station/src/pointcloud_assembler/include/pointcloud_assembler/pointcloud_assembler_node.hpp
+++ b/ground_station/src/pointcloud_assembler/include/pointcloud_assembler/pointcloud_assembler_node.hpp
@@ -6,6 +6,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 #include "pointcloud_assembler/pointcloud_assembler.hpp"
 
@@ -19,8 +21,8 @@ namespace pointcloud_assembler {
 ///   window_duration_sec (double) — time window for accumulation (default: 1.0)
 ///   max_clouds        (int)   — max clouds in buffer (default: 100)
 ///   publish_rate_hz   (double) — assembled cloud publish rate (default: 10.0)
-///   output_frame      (string) — frame_id for the assembled cloud
-///                                (default: "odom")
+///   output_frame      (string) — target TF frame for assembled cloud
+///                                (default: "map")
 class PointcloudAssemblerNode : public rclcpp::Node {
  public:
   explicit PointcloudAssemblerNode(
@@ -36,6 +38,8 @@ class PointcloudAssemblerNode : public rclcpp::Node {
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr publisher_;
   rclcpp::TimerBase::SharedPtr publish_timer_;
   std::string output_frame_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 };
 
 }  // namespace pointcloud_assembler

--- a/ground_station/src/pointcloud_assembler/package.xml
+++ b/ground_station/src/pointcloud_assembler/package.xml
@@ -12,9 +12,13 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_sensor_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/ground_station/src/pointcloud_assembler/src/pointcloud_assembler_node.cpp
+++ b/ground_station/src/pointcloud_assembler/src/pointcloud_assembler_node.cpp
@@ -3,6 +3,10 @@
 #include <chrono>
 #include <functional>
 
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <tf2/exceptions.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
+
 namespace pointcloud_assembler {
 
 PointcloudAssemblerNode::PointcloudAssemblerNode(
@@ -12,7 +16,7 @@ PointcloudAssemblerNode::PointcloudAssemblerNode(
   declare_parameter("window_duration_sec", 1.0);
   declare_parameter("max_clouds", 100);
   declare_parameter("publish_rate_hz", 10.0);
-  declare_parameter("output_frame", std::string("odom"));
+  declare_parameter("output_frame", std::string("map"));
 
   AssemblerConfig config;
   config.window_duration_sec =
@@ -22,6 +26,9 @@ PointcloudAssemblerNode::PointcloudAssemblerNode(
   assembler_ = std::make_unique<PointcloudAssembler>(config);
 
   output_frame_ = get_parameter("output_frame").as_string();
+
+  tf_buffer_ = std::make_shared<tf2_ros::Buffer>(get_clock());
+  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
   // DESIGN: best_effort QoS matches real micro-ROS sensor publishers
   // (see CLAUDE.md QoS section).
@@ -63,7 +70,24 @@ PointcloudAssemblerNode::PointcloudAssemblerNode(
 
 void PointcloudAssemblerNode::on_pointcloud(
     sensor_msgs::msg::PointCloud2::SharedPtr msg) {
-  assembler_->add_cloud(*msg);
+  geometry_msgs::msg::TransformStamped transform;
+  try {
+    // DESIGN: 100ms timeout matches the 15Hz sensor rate (66ms period).
+    // Clouds arriving before TF is available are skipped, not accumulated
+    // in the wrong frame.
+    transform = tf_buffer_->lookupTransform(
+        output_frame_, msg->header.frame_id, msg->header.stamp,
+        rclcpp::Duration::from_nanoseconds(100000000LL));
+  } catch (const tf2::TransformException& ex) {
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 1000,
+                         "TF not available for frame '%s': %s",
+                         msg->header.frame_id.c_str(), ex.what());
+    return;
+  }
+
+  sensor_msgs::msg::PointCloud2 cloud_transformed;
+  tf2::doTransform(*msg, cloud_transformed, transform);
+  assembler_->add_cloud(cloud_transformed);
 }
 
 void PointcloudAssemblerNode::publish_timer_callback() {

--- a/ground_station/src/slam_node/CMakeLists.txt
+++ b/ground_station/src/slam_node/CMakeLists.txt
@@ -9,10 +9,14 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_sensor_msgs REQUIRED)
 
 # Library: occupancy map logic (reusable, testable without ROS node)
 add_library(occupancy_map
@@ -39,10 +43,14 @@ target_include_directories(slam_node_exec PUBLIC
 )
 target_link_libraries(slam_node_exec occupancy_map)
 ament_target_dependencies(slam_node_exec
+  geometry_msgs
   nav_msgs
   rclcpp
   sensor_msgs
   std_msgs
+  tf2
+  tf2_ros
+  tf2_sensor_msgs
 )
 set_target_properties(slam_node_exec PROPERTIES OUTPUT_NAME slam_node)
 

--- a/ground_station/src/slam_node/include/slam_node/slam_node.hpp
+++ b/ground_station/src/slam_node/include/slam_node/slam_node.hpp
@@ -7,6 +7,8 @@
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 #include "slam_node/occupancy_map.hpp"
 
@@ -18,9 +20,9 @@ namespace slam_node {
 /// Publishes /slam/map (nav_msgs/OccupancyGrid) at a configurable rate.
 /// Publishes /slam/map_3d (sensor_msgs/PointCloud2) alongside the 2D map.
 ///
-/// DESIGN: No TF2 transforms applied. Assumes incoming pointclouds are
-/// expressed in a common map-relative frame. This matches the simulator
-/// output and is sufficient until a pose estimator (issue #10) is added.
+/// Incoming pointclouds are transformed to the map frame via TF2 before
+/// insertion. Clouds with unavailable transforms are skipped to avoid
+/// accumulating data in wrong frames.
 class SlamNode : public rclcpp::Node {
  public:
   explicit SlamNode(const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
@@ -36,6 +38,8 @@ class SlamNode : public rclcpp::Node {
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr map_3d_pub_;
   rclcpp::TimerBase::SharedPtr publish_timer_;
   std::string map_frame_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 };
 
 }  // namespace slam_node

--- a/ground_station/src/slam_node/package.xml
+++ b/ground_station/src/slam_node/package.xml
@@ -12,10 +12,14 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_sensor_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/ground_station/src/slam_node/src/slam_node.cpp
+++ b/ground_station/src/slam_node/src/slam_node.cpp
@@ -4,6 +4,10 @@
 #include <functional>
 #include <string>
 
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <tf2/exceptions.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
+
 namespace slam_node {
 
 SlamNode::SlamNode(const rclcpp::NodeOptions& options)
@@ -26,6 +30,9 @@ SlamNode::SlamNode(const rclcpp::NodeOptions& options)
   config.height_min = get_parameter("map_height_min").as_double();
   config.height_max = get_parameter("map_height_max").as_double();
   map_ = std::make_unique<OccupancyMap>(config);
+
+  tf_buffer_ = std::make_shared<tf2_ros::Buffer>(get_clock());
+  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
   // DESIGN: best_effort QoS matches the real micro-ROS sensor publishers
   // (see CLAUDE.md QoS section). Drone pointclouds are sensor data.
@@ -69,7 +76,29 @@ SlamNode::SlamNode(const rclcpp::NodeOptions& options)
 
 void SlamNode::pointcloud_callback(
     const sensor_msgs::msg::PointCloud2::SharedPtr msg) {
-  map_->add_pointcloud(*msg);
+  if (msg->header.frame_id == map_frame_) {
+    map_->add_pointcloud(*msg);
+    return;
+  }
+
+  geometry_msgs::msg::TransformStamped transform;
+  try {
+    // DESIGN: 100ms timeout matches the 15Hz sensor rate (66ms period).
+    // Clouds arriving before TF is available are skipped, not accumulated
+    // in the wrong frame.
+    transform = tf_buffer_->lookupTransform(
+        map_frame_, msg->header.frame_id, msg->header.stamp,
+        rclcpp::Duration::from_nanoseconds(100000000LL));
+  } catch (const tf2::TransformException& ex) {
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 1000,
+                         "TF not available for frame '%s': %s",
+                         msg->header.frame_id.c_str(), ex.what());
+    return;
+  }
+
+  sensor_msgs::msg::PointCloud2 cloud_map;
+  tf2::doTransform(*msg, cloud_map, transform);
+  map_->add_pointcloud(cloud_map);
 }
 
 void SlamNode::publish_map() {


### PR DESCRIPTION
## Summary

- Add `tf2_ros::Buffer` + `tf2_ros::TransformListener` to **slam_node** and **pointcloud_assembler_node**
- Transform each incoming `PointCloud2` to the `map` frame via `tf2::doTransform()` before accumulation
- Skip clouds whose transform is not yet available (`tf2::TransformException`) to avoid accumulating garbage in wrong frames
- Update launch file: add `tf_broadcaster` (from #53) and `pose_extractor` (from #52) nodes in correct startup order; fix `output_frame` from `odom` → `map`

## Changes

### slam_node
- `slam_node.hpp`: add `tf2_ros::Buffer` + `tf2_ros::TransformListener` members; remove stale DESIGN comment about no TF2
- `slam_node.cpp`: initialize TF2 buffer/listener; `pointcloud_callback` now transforms clouds to `map` frame before `add_pointcloud()`; clouds already in `map` frame bypass the lookup
- `CMakeLists.txt` / `package.xml`: add `geometry_msgs`, `tf2`, `tf2_ros`, `tf2_sensor_msgs`

### pointcloud_assembler
- `pointcloud_assembler_node.hpp`: add `tf2_ros::Buffer` + `tf2_ros::TransformListener` members
- `pointcloud_assembler_node.cpp`: initialize TF2; `on_pointcloud` transforms to `output_frame` before `add_cloud()`; default `output_frame` changed from `odom` → `map`
- `pointcloud_assembler.hpp`: update DESIGN comment to reflect TF responsibility sits in the node layer
- `CMakeLists.txt` / `package.xml`: add `geometry_msgs`, `tf2`, `tf2_ros`, `tf2_sensor_msgs`

### launch
- Add `tf_broadcaster` node (package `drone_swarm_tf_broadcaster`, from #53) — must start first to publish static sensor→base_link transforms
- Add `pose_extractor` node (package `drone_swarm_pose_extractor`, from #52) — publishes MAVLink EKF → map→base_link TF
- Fix `output_frame` parameter to `map`

## Test plan

- [x] Docker build passes: `docker compose -f docker/docker-compose.yml run ground-build` (2 tests, 0 failures)
- [ ] Integration: with #52 + #53 merged, run tof_simulator + tf_broadcaster + pose_extractor + assembler + slam and verify map accumulates correctly in Foxglove

Closes #59