### PR TITLE
feat(ground): static TF broadcaster for drone sensors

### DIFF
--- a/ground_station/src/tf_broadcaster/CMakeLists.txt
+++ b/ground_station/src/tf_broadcaster/CMakeLists.txt
@@ -1,0 +1,70 @@
+cmake_minimum_required(VERSION 3.8)
+project(drone_swarm_tf_broadcaster)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(tf2_ros REQUIRED)
+
+# Library: pure transform logic (no ROS spin, testable standalone)
+add_library(drone_tf_broadcaster_lib
+  src/drone_tf_broadcaster.cpp
+)
+target_include_directories(drone_tf_broadcaster_lib PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+ament_target_dependencies(drone_tf_broadcaster_lib
+  geometry_msgs
+  rclcpp
+  tf2_ros
+)
+
+# Executable: ROS 2 node
+add_executable(drone_tf_broadcaster_node
+  src/main.cpp
+)
+target_include_directories(drone_tf_broadcaster_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(drone_tf_broadcaster_node drone_tf_broadcaster_lib)
+ament_target_dependencies(drone_tf_broadcaster_node
+  geometry_msgs
+  rclcpp
+  tf2_ros
+)
+
+install(TARGETS drone_tf_broadcaster_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY launch/
+  DESTINATION share/${PROJECT_NAME}/launch
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_drone_tf_broadcaster
+    test/test_drone_tf_broadcaster.cpp
+  )
+  target_link_libraries(test_drone_tf_broadcaster drone_tf_broadcaster_lib)
+  target_include_directories(test_drone_tf_broadcaster PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  )
+  ament_target_dependencies(test_drone_tf_broadcaster
+    geometry_msgs
+    rclcpp
+    tf2_ros
+  )
+endif()
+
+ament_package()

--- a/ground_station/src/tf_broadcaster/include/tf_broadcaster/drone_tf_broadcaster.hpp
+++ b/ground_station/src/tf_broadcaster/include/tf_broadcaster/drone_tf_broadcaster.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/static_transform_broadcaster.h>
+
+namespace tf_broadcaster {
+
+// DESIGN: 5cm offset matches tof_simulator default_sensor_poses() so that
+// the TF tree is consistent with simulated pointcloud origins.
+constexpr double kDefaultSensorOffset = 0.05;  // 5cm from drone center
+
+struct SensorOffset {
+  double x = 0.0;
+  double y = 0.0;
+  double z = 0.0;
+  double yaw = 0.0;  // radians, rotation around Z-axis (FLU frame)
+};
+
+struct TfConfig {
+  int drone_id = 1;
+  SensorOffset tof_front;
+  SensorOffset tof_right;
+  SensorOffset tof_back;
+  SensorOffset tof_left;
+  SensorOffset camera;
+};
+
+/// Returns defaults consistent with tof_simulator default_sensor_poses().
+/// FLU frame: +X=forward, +Y=left, +Z=up.
+TfConfig default_config();
+
+/// Build one TransformStamped from parent_frame to child_frame.
+/// Uses zero timestamp (appropriate for static transforms).
+geometry_msgs::msg::TransformStamped make_transform(
+    const std::string& parent_frame, const std::string& child_frame,
+    const SensorOffset& offset);
+
+/// Build all 5 static transforms (4 ToF + 1 camera) for the given config.
+std::vector<geometry_msgs::msg::TransformStamped> build_transforms(
+    const TfConfig& config);
+
+class DroneTfBroadcaster : public rclcpp::Node {
+ public:
+  explicit DroneTfBroadcaster(
+      const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
+
+ private:
+  std::unique_ptr<tf2_ros::StaticTransformBroadcaster> broadcaster_;
+};
+
+}  // namespace tf_broadcaster

--- a/ground_station/src/tf_broadcaster/launch/drone_tf_broadcaster.launch.py
+++ b/ground_station/src/tf_broadcaster/launch/drone_tf_broadcaster.launch.py
@@ -1,0 +1,71 @@
+"""Launch file for the drone TF broadcaster node."""
+
+import math
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        DeclareLaunchArgument('drone_id', default_value='1'),
+
+        DeclareLaunchArgument('tof_front_x', default_value='0.05'),
+        DeclareLaunchArgument('tof_front_y', default_value='0.0'),
+        DeclareLaunchArgument('tof_front_z', default_value='0.0'),
+        DeclareLaunchArgument('tof_front_yaw', default_value='0.0'),
+
+        DeclareLaunchArgument('tof_right_x', default_value='0.0'),
+        DeclareLaunchArgument('tof_right_y', default_value='-0.05'),
+        DeclareLaunchArgument('tof_right_z', default_value='0.0'),
+        DeclareLaunchArgument('tof_right_yaw',
+                              default_value=str(-math.pi / 2.0)),
+
+        DeclareLaunchArgument('tof_back_x', default_value='-0.05'),
+        DeclareLaunchArgument('tof_back_y', default_value='0.0'),
+        DeclareLaunchArgument('tof_back_z', default_value='0.0'),
+        DeclareLaunchArgument('tof_back_yaw', default_value=str(math.pi)),
+
+        DeclareLaunchArgument('tof_left_x', default_value='0.0'),
+        DeclareLaunchArgument('tof_left_y', default_value='0.05'),
+        DeclareLaunchArgument('tof_left_z', default_value='0.0'),
+        DeclareLaunchArgument('tof_left_yaw',
+                              default_value=str(math.pi / 2.0)),
+
+        DeclareLaunchArgument('camera_x', default_value='0.0'),
+        DeclareLaunchArgument('camera_y', default_value='0.0'),
+        DeclareLaunchArgument('camera_z', default_value='0.0'),
+        DeclareLaunchArgument('camera_yaw', default_value='0.0'),
+
+        Node(
+            package='drone_swarm_tf_broadcaster',
+            executable='drone_tf_broadcaster_node',
+            name='drone_tf_broadcaster',
+            parameters=[{
+                'drone_id': LaunchConfiguration('drone_id'),
+                'tof_front_x': LaunchConfiguration('tof_front_x'),
+                'tof_front_y': LaunchConfiguration('tof_front_y'),
+                'tof_front_z': LaunchConfiguration('tof_front_z'),
+                'tof_front_yaw': LaunchConfiguration('tof_front_yaw'),
+                'tof_right_x': LaunchConfiguration('tof_right_x'),
+                'tof_right_y': LaunchConfiguration('tof_right_y'),
+                'tof_right_z': LaunchConfiguration('tof_right_z'),
+                'tof_right_yaw': LaunchConfiguration('tof_right_yaw'),
+                'tof_back_x': LaunchConfiguration('tof_back_x'),
+                'tof_back_y': LaunchConfiguration('tof_back_y'),
+                'tof_back_z': LaunchConfiguration('tof_back_z'),
+                'tof_back_yaw': LaunchConfiguration('tof_back_yaw'),
+                'tof_left_x': LaunchConfiguration('tof_left_x'),
+                'tof_left_y': LaunchConfiguration('tof_left_y'),
+                'tof_left_z': LaunchConfiguration('tof_left_z'),
+                'tof_left_yaw': LaunchConfiguration('tof_left_yaw'),
+                'camera_x': LaunchConfiguration('camera_x'),
+                'camera_y': LaunchConfiguration('camera_y'),
+                'camera_z': LaunchConfiguration('camera_z'),
+                'camera_yaw': LaunchConfiguration('camera_yaw'),
+            }],
+            output='screen',
+        ),
+    ])

--- a/ground_station/src/tf_broadcaster/package.xml
+++ b/ground_station/src/tf_broadcaster/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>drone_swarm_tf_broadcaster</name>
+  <version>0.1.0</version>
+  <description>
+    Publishes static TF transforms for all drone sensors (4x VL53L8CX ToF +
+    OV2640 camera) relative to the drone base_link frame.
+  </description>
+  <maintainer email="maintainer@todo.todo">Maintainer</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>geometry_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>tf2_ros</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ground_station/src/tf_broadcaster/src/drone_tf_broadcaster.cpp
+++ b/ground_station/src/tf_broadcaster/src/drone_tf_broadcaster.cpp
@@ -1,0 +1,137 @@
+#include "tf_broadcaster/drone_tf_broadcaster.hpp"
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+namespace tf_broadcaster {
+
+TfConfig default_config() {
+  TfConfig cfg;
+  // DESIGN: positions and yaw angles mirror tof_simulator default_sensor_poses()
+  // so that TF frames are consistent with simulated pointcloud origins.
+  // FLU convention: +X=forward, +Y=left, +Z=up.
+  cfg.tof_front = {kDefaultSensorOffset, 0.0, 0.0, 0.0};
+  cfg.tof_right = {0.0, -kDefaultSensorOffset, 0.0, -M_PI / 2.0};
+  cfg.tof_back = {-kDefaultSensorOffset, 0.0, 0.0, M_PI};
+  cfg.tof_left = {0.0, kDefaultSensorOffset, 0.0, M_PI / 2.0};
+  // DESIGN: camera (OV2640) is mounted on XIAO at drone center;
+  // exact position TBD after physical assembly.
+  cfg.camera = {0.0, 0.0, 0.0, 0.0};
+  return cfg;
+}
+
+geometry_msgs::msg::TransformStamped make_transform(
+    const std::string& parent_frame, const std::string& child_frame,
+    const SensorOffset& offset) {
+  geometry_msgs::msg::TransformStamped t;
+  // Zero timestamp: TF2 treats t=0 as "always valid" for static transforms.
+  t.header.stamp.sec = 0;
+  t.header.stamp.nanosec = 0;
+  t.header.frame_id = parent_frame;
+  t.child_frame_id = child_frame;
+
+  t.transform.translation.x = offset.x;
+  t.transform.translation.y = offset.y;
+  t.transform.translation.z = offset.z;
+
+  // Quaternion from yaw-only rotation (around Z): q = [0, 0, sin(yaw/2), cos(yaw/2)]
+  t.transform.rotation.x = 0.0;
+  t.transform.rotation.y = 0.0;
+  t.transform.rotation.z = std::sin(offset.yaw / 2.0);
+  t.transform.rotation.w = std::cos(offset.yaw / 2.0);
+
+  return t;
+}
+
+std::vector<geometry_msgs::msg::TransformStamped> build_transforms(
+    const TfConfig& config) {
+  const std::string base =
+      "drone_" + std::to_string(config.drone_id) + "/base_link";
+  const std::string ns = "drone_" + std::to_string(config.drone_id) + "/";
+
+  return {
+      make_transform(base, ns + "tof_front", config.tof_front),
+      make_transform(base, ns + "tof_right", config.tof_right),
+      make_transform(base, ns + "tof_back", config.tof_back),
+      make_transform(base, ns + "tof_left", config.tof_left),
+      make_transform(base, ns + "camera", config.camera),
+  };
+}
+
+DroneTfBroadcaster::DroneTfBroadcaster(const rclcpp::NodeOptions& options)
+    : Node("drone_tf_broadcaster", options) {
+  declare_parameter("drone_id", 1);
+
+  declare_parameter("tof_front_x", kDefaultSensorOffset);
+  declare_parameter("tof_front_y", 0.0);
+  declare_parameter("tof_front_z", 0.0);
+  declare_parameter("tof_front_yaw", 0.0);
+
+  declare_parameter("tof_right_x", 0.0);
+  declare_parameter("tof_right_y", -kDefaultSensorOffset);
+  declare_parameter("tof_right_z", 0.0);
+  declare_parameter("tof_right_yaw", -M_PI / 2.0);
+
+  declare_parameter("tof_back_x", -kDefaultSensorOffset);
+  declare_parameter("tof_back_y", 0.0);
+  declare_parameter("tof_back_z", 0.0);
+  declare_parameter("tof_back_yaw", M_PI);
+
+  declare_parameter("tof_left_x", 0.0);
+  declare_parameter("tof_left_y", kDefaultSensorOffset);
+  declare_parameter("tof_left_z", 0.0);
+  declare_parameter("tof_left_yaw", M_PI / 2.0);
+
+  declare_parameter("camera_x", 0.0);
+  declare_parameter("camera_y", 0.0);
+  declare_parameter("camera_z", 0.0);
+  declare_parameter("camera_yaw", 0.0);
+
+  TfConfig config;
+  config.drone_id = get_parameter("drone_id").as_int();
+  config.tof_front = {
+      get_parameter("tof_front_x").as_double(),
+      get_parameter("tof_front_y").as_double(),
+      get_parameter("tof_front_z").as_double(),
+      get_parameter("tof_front_yaw").as_double(),
+  };
+  config.tof_right = {
+      get_parameter("tof_right_x").as_double(),
+      get_parameter("tof_right_y").as_double(),
+      get_parameter("tof_right_z").as_double(),
+      get_parameter("tof_right_yaw").as_double(),
+  };
+  config.tof_back = {
+      get_parameter("tof_back_x").as_double(),
+      get_parameter("tof_back_y").as_double(),
+      get_parameter("tof_back_z").as_double(),
+      get_parameter("tof_back_yaw").as_double(),
+  };
+  config.tof_left = {
+      get_parameter("tof_left_x").as_double(),
+      get_parameter("tof_left_y").as_double(),
+      get_parameter("tof_left_z").as_double(),
+      get_parameter("tof_left_yaw").as_double(),
+  };
+  config.camera = {
+      get_parameter("camera_x").as_double(),
+      get_parameter("camera_y").as_double(),
+      get_parameter("camera_z").as_double(),
+      get_parameter("camera_yaw").as_double(),
+  };
+
+  broadcaster_ = std::make_unique<tf2_ros::StaticTransformBroadcaster>(this);
+  broadcaster_->sendTransform(build_transforms(config));
+
+  RCLCPP_INFO(get_logger(),
+              "Published 5 static TF transforms for drone_%d "
+              "(tof_front, tof_right, tof_back, tof_left, camera)",
+              config.drone_id);
+}
+
+}  // namespace tf_broadcaster

--- a/ground_station/src/tf_broadcaster/src/main.cpp
+++ b/ground_station/src/tf_broadcaster/src/main.cpp
@@ -1,0 +1,10 @@
+#include <rclcpp/rclcpp.hpp>
+
+#include "tf_broadcaster/drone_tf_broadcaster.hpp"
+
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<tf_broadcaster::DroneTfBroadcaster>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/ground_station/src/tf_broadcaster/test/test_drone_tf_broadcaster.cpp
+++ b/ground_station/src/tf_broadcaster/test/test_drone_tf_broadcaster.cpp
@@ -1,0 +1,160 @@
+// cppcheck-suppress-file syntaxError
+#include "tf_broadcaster/drone_tf_broadcaster.hpp"
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+namespace tf_broadcaster {
+namespace {
+
+// --- default_config ---
+
+TEST(DefaultConfig, FrontSensorFacesPositiveX) {
+  auto cfg = default_config();
+  EXPECT_NEAR(cfg.tof_front.x, kDefaultSensorOffset, 1e-9);
+  EXPECT_NEAR(cfg.tof_front.y, 0.0, 1e-9);
+  EXPECT_NEAR(cfg.tof_front.yaw, 0.0, 1e-9);
+}
+
+TEST(DefaultConfig, RightSensorFacesNegativeY) {
+  auto cfg = default_config();
+  EXPECT_NEAR(cfg.tof_right.x, 0.0, 1e-9);
+  EXPECT_NEAR(cfg.tof_right.y, -kDefaultSensorOffset, 1e-9);
+  EXPECT_NEAR(cfg.tof_right.yaw, -M_PI / 2.0, 1e-9);
+}
+
+TEST(DefaultConfig, BackSensorFacesNegativeX) {
+  auto cfg = default_config();
+  EXPECT_NEAR(cfg.tof_back.x, -kDefaultSensorOffset, 1e-9);
+  EXPECT_NEAR(cfg.tof_back.y, 0.0, 1e-9);
+  EXPECT_NEAR(cfg.tof_back.yaw, M_PI, 1e-9);
+}
+
+TEST(DefaultConfig, LeftSensorFacesPositiveY) {
+  auto cfg = default_config();
+  EXPECT_NEAR(cfg.tof_left.x, 0.0, 1e-9);
+  EXPECT_NEAR(cfg.tof_left.y, kDefaultSensorOffset, 1e-9);
+  EXPECT_NEAR(cfg.tof_left.yaw, M_PI / 2.0, 1e-9);
+}
+
+TEST(DefaultConfig, CameraAtOriginNoRotation) {
+  auto cfg = default_config();
+  EXPECT_NEAR(cfg.camera.x, 0.0, 1e-9);
+  EXPECT_NEAR(cfg.camera.y, 0.0, 1e-9);
+  EXPECT_NEAR(cfg.camera.z, 0.0, 1e-9);
+  EXPECT_NEAR(cfg.camera.yaw, 0.0, 1e-9);
+}
+
+TEST(DefaultConfig, DefaultDroneIdIsOne) {
+  auto cfg = default_config();
+  EXPECT_EQ(cfg.drone_id, 1);
+}
+
+// --- make_transform ---
+
+TEST(MakeTransform, FrameNamesAreSet) {
+  SensorOffset offset{};
+  auto t = make_transform("parent/base_link", "parent/sensor", offset);
+  EXPECT_EQ(t.header.frame_id, "parent/base_link");
+  EXPECT_EQ(t.child_frame_id, "parent/sensor");
+}
+
+TEST(MakeTransform, ZeroOffsetProducesIdentityRotation) {
+  SensorOffset offset{0.0, 0.0, 0.0, 0.0};
+  auto t = make_transform("p", "c", offset);
+  EXPECT_NEAR(t.transform.rotation.x, 0.0, 1e-9);
+  EXPECT_NEAR(t.transform.rotation.y, 0.0, 1e-9);
+  EXPECT_NEAR(t.transform.rotation.z, 0.0, 1e-9);
+  EXPECT_NEAR(t.transform.rotation.w, 1.0, 1e-9);
+}
+
+TEST(MakeTransform, TranslationMatchesOffset) {
+  SensorOffset offset{0.05, -0.05, 0.01, 0.0};
+  auto t = make_transform("p", "c", offset);
+  EXPECT_NEAR(t.transform.translation.x, 0.05, 1e-9);
+  EXPECT_NEAR(t.transform.translation.y, -0.05, 1e-9);
+  EXPECT_NEAR(t.transform.translation.z, 0.01, 1e-9);
+}
+
+TEST(MakeTransform, YawPiHalfProducesCorrectQuaternion) {
+  SensorOffset offset{0.0, 0.0, 0.0, M_PI / 2.0};
+  auto t = make_transform("p", "c", offset);
+  EXPECT_NEAR(t.transform.rotation.x, 0.0, 1e-9);
+  EXPECT_NEAR(t.transform.rotation.y, 0.0, 1e-9);
+  EXPECT_NEAR(t.transform.rotation.z, std::sin(M_PI / 4.0), 1e-9);
+  EXPECT_NEAR(t.transform.rotation.w, std::cos(M_PI / 4.0), 1e-9);
+}
+
+TEST(MakeTransform, YawNegPiHalfProducesCorrectQuaternion) {
+  SensorOffset offset{0.0, 0.0, 0.0, -M_PI / 2.0};
+  auto t = make_transform("p", "c", offset);
+  EXPECT_NEAR(t.transform.rotation.z, std::sin(-M_PI / 4.0), 1e-9);
+  EXPECT_NEAR(t.transform.rotation.w, std::cos(-M_PI / 4.0), 1e-9);
+}
+
+TEST(MakeTransform, YawPiProducesCorrectQuaternion) {
+  SensorOffset offset{0.0, 0.0, 0.0, M_PI};
+  auto t = make_transform("p", "c", offset);
+  // q = [0, 0, sin(pi/2), cos(pi/2)] = [0, 0, 1, 0]
+  EXPECT_NEAR(t.transform.rotation.z, 1.0, 1e-9);
+  EXPECT_NEAR(t.transform.rotation.w, 0.0, 1e-9);
+}
+
+TEST(MakeTransform, UsesZeroTimestamp) {
+  SensorOffset offset{};
+  auto t = make_transform("p", "c", offset);
+  EXPECT_EQ(t.header.stamp.sec, 0);
+  EXPECT_EQ(t.header.stamp.nanosec, 0u);
+}
+
+// --- build_transforms ---
+
+TEST(BuildTransforms, ReturnsFiveTransforms) {
+  auto transforms = build_transforms(default_config());
+  EXPECT_EQ(transforms.size(), 5u);
+}
+
+TEST(BuildTransforms, ParentFrameIsBaseLink) {
+  auto transforms = build_transforms(default_config());
+  for (const auto& t : transforms) {
+    EXPECT_EQ(t.header.frame_id, "drone_1/base_link");
+  }
+}
+
+TEST(BuildTransforms, ChildFrameNamesUseDroneIdNamespace) {
+  auto transforms = build_transforms(default_config());
+  EXPECT_EQ(transforms[0].child_frame_id, "drone_1/tof_front");
+  EXPECT_EQ(transforms[1].child_frame_id, "drone_1/tof_right");
+  EXPECT_EQ(transforms[2].child_frame_id, "drone_1/tof_back");
+  EXPECT_EQ(transforms[3].child_frame_id, "drone_1/tof_left");
+  EXPECT_EQ(transforms[4].child_frame_id, "drone_1/camera");
+}
+
+TEST(BuildTransforms, DroneIdTwoUsesCorrectNamespace) {
+  TfConfig cfg = default_config();
+  cfg.drone_id = 2;
+  auto transforms = build_transforms(cfg);
+  EXPECT_EQ(transforms[0].header.frame_id, "drone_2/base_link");
+  EXPECT_EQ(transforms[0].child_frame_id, "drone_2/tof_front");
+}
+
+TEST(BuildTransforms, FrontTransformHasCorrectTranslation) {
+  auto transforms = build_transforms(default_config());
+  const auto& t = transforms[0];  // tof_front
+  EXPECT_NEAR(t.transform.translation.x, kDefaultSensorOffset, 1e-9);
+  EXPECT_NEAR(t.transform.translation.y, 0.0, 1e-9);
+}
+
+TEST(BuildTransforms, RightTransformHasCorrectTranslation) {
+  auto transforms = build_transforms(default_config());
+  const auto& t = transforms[1];  // tof_right
+  EXPECT_NEAR(t.transform.translation.y, -kDefaultSensorOffset, 1e-9);
+}
+
+}  // namespace
+}  // namespace tf_broadcaster


### PR DESCRIPTION
## Summary

- Adds `drone_swarm_tf_broadcaster` ROS 2 package at `ground_station/src/tf_broadcaster/`
- Publishes 5 static TF transforms on startup: `drone_N/base_link` → `drone_N/tof_front`, `tof_right`, `tof_back`, `tof_left`, `camera`
- Sensor positions/orientations match `tof_simulator` `default_sensor_poses()` (5cm offsets, 90° yaw increments, FLU frame)
- All 20 offsets (x/y/z/yaw per sensor) configurable via ROS parameters
- 18 GTests covering `default_config()`, `make_transform()`, and `build_transforms()`

## Design notes

- Separates pure transform logic (`default_config`, `make_transform`, `build_transforms`) into a testable library, separate from the ROS node — same pattern as `tof_simulator` and `pointcloud_assembler`
- Uses zero timestamp for static transforms (TF2 treats `t=0` as "always valid")
- Quaternion computed from yaw-only rotation (sensors mounted horizontally, no pitch/roll)

## Test plan

- [x] `docker compose -f docker/docker-compose.yml run ground-build` passes (no regression)
- [x] GitHub Actions CI will build and test `drone_swarm_tf_broadcaster` via `--packages-up-to-regex 'drone_swarm_.*'`
- [x] 18 unit tests: default config values, translation/rotation correctness, frame name namespacing, 5 transforms returned

Closes #58